### PR TITLE
Add fast CIDR.Contains implementation

### DIFF
--- a/main_windows.go
+++ b/main_windows.go
@@ -48,7 +48,9 @@ func main() {
 		os.Exit(ExitSetupFailed)
 	}
 
-	device := device.NewDevice(tun, logger)
+	device := device.NewDevice(tun, &device.DeviceOptions{
+		Logger: logger,
+	})
 	device.Up()
 	logger.Info.Println("Device started")
 

--- a/wgcfg/ip_test.go
+++ b/wgcfg/ip_test.go
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 WireGuard LLC. All Rights Reserved.
+ */
+
+package wgcfg_test
+
+import (
+	"testing"
+
+	"github.com/tailscale/wireguard-go/wgcfg"
+)
+
+func TestCIDRContains(t *testing.T) {
+	t.Run("home router test", func(t *testing.T) {
+		r, err := wgcfg.ParseCIDR("192.168.0.0/24")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("192.168.0.1")
+		if ip == nil {
+			t.Fatalf("address failed to parse")
+		}
+		if !r.Contains(ip) {
+			t.Fatalf("'%s' should contain '%s'", r, ip)
+		}
+	})
+
+	t.Run("IPv4 outside network", func(t *testing.T) {
+		r, err := wgcfg.ParseCIDR("192.168.0.0/30")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("192.168.0.4")
+		if ip == nil {
+			t.Fatalf("address failed to parse")
+		}
+		if r.Contains(ip) {
+			t.Fatalf("'%s' should not contain '%s'", r, ip)
+		}
+	})
+
+	t.Run("IPv4 does not contain IPv6", func(t *testing.T) {
+		r, err := wgcfg.ParseCIDR("192.168.0.0/24")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("2001:db8:85a3:0:0:8a2e:370:7334")
+		if ip == nil {
+			t.Fatalf("address failed to parse")
+		}
+		if r.Contains(ip) {
+			t.Fatalf("'%s' should not contain '%s'", r, ip)
+		}
+	})
+
+	t.Run("IPv6 inside network", func(t *testing.T) {
+		r, err := wgcfg.ParseCIDR("2001:db8:1234::/48")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("2001:db8:1234:0000:0000:0000:0000:0001")
+		if ip == nil {
+			t.Fatalf("ParseIP returned nil pointer")
+		}
+		if !r.Contains(ip) {
+			t.Fatalf("'%s' should not contain '%s'", r, ip)
+		}
+	})
+
+	t.Run("IPv6 outside network", func(t *testing.T) {
+		r, err := wgcfg.ParseCIDR("2001:db8:1234:0:190b:0:1982::/126")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("2001:db8:1234:0:190b:0:1982:4")
+		if ip == nil {
+			t.Fatalf("ParseIP returned nil pointer")
+		}
+		if r.Contains(ip) {
+			t.Fatalf("'%s' should not contain '%s'", r, ip)
+		}
+	})
+}
+
+func BenchmarkCIDRContainsIPv4(b *testing.B) {
+	b.Run("IPv4", func(b *testing.B) {
+		r, err := wgcfg.ParseCIDR("192.168.1.0/24")
+		if err != nil {
+			b.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("1.2.3.4")
+		if ip == nil {
+			b.Fatalf("ParseIP returned nil pointer")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			r.Contains(ip)
+		}
+	})
+
+	b.Run("IPv6", func(b *testing.B) {
+		r, err := wgcfg.ParseCIDR("2001:db8:1234::/48")
+		if err != nil {
+			b.Fatal(err)
+		}
+		ip := wgcfg.ParseIP("2001:db8:1234:0000:0000:0000:0000:0001")
+		if ip == nil {
+			b.Fatalf("ParseIP returned nil pointer")
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			r.Contains(ip)
+		}
+	})
+}


### PR DESCRIPTION
Before:
```text
$ go test -benchmem -bench=BenchmarkCIDRContains -benchtime=10s ./wgcfg
goos: windows
goarch: amd64
pkg: github.com/tailscale/wireguard-go/wgcfg
BenchmarkCIDRContainsIPv4/IPv4-8                138954278               85.2 ns/op            52 B/op          2 allocs/op
BenchmarkCIDRContainsIPv4/IPv6-8                100000000              102 ns/op              64 B/op          2 allocs/op
PASS
ok      github.com/tailscale/wireguard-go/wgcfg 31.010s
```

After:
```
$ go test -benchmem -bench=BenchmarkCIDRContains -benchtime=10s ./wgcfg
goos: windows
goarch: amd64
pkg: github.com/tailscale/wireguard-go/wgcfg
BenchmarkCIDRContainsIPv4/IPv4-8                1000000000              11.7 ns/op             0 B/op          0 allocs/op
BenchmarkCIDRContainsIPv4/IPv6-8                721590703               16.6 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/tailscale/wireguard-go/wgcfg 26.666s
```

Fixes https://github.com/tailscale/tailscale/issues/73.