### PR TITLE
rwcancel: no-op builds for windows and darwin

### DIFF
--- a/rwcancel/fdset.go
+++ b/rwcancel/fdset.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2017-2019 WireGuard LLC. All Rights Reserved.

--- a/rwcancel/rwcancel.go
+++ b/rwcancel/rwcancel.go
@@ -1,8 +1,12 @@
+// +build !windows
+
 /* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2017-2019 WireGuard LLC. All Rights Reserved.
  */
 
+// Package rwcancel implements cancelable read/write operations on
+// a file descriptor.
 package rwcancel
 
 import (

--- a/rwcancel/rwcancel_windows.go
+++ b/rwcancel/rwcancel_windows.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+package rwcancel
+
+type RWCancel struct {
+}
+
+func (*RWCancel) Cancel() {}

--- a/rwcancel/select_default.go
+++ b/rwcancel/select_default.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows
 
 /* SPDX-License-Identifier: MIT
  *
@@ -10,5 +10,6 @@ package rwcancel
 import "golang.org/x/sys/unix"
 
 func unixSelect(nfd int, r *unix.FdSet, w *unix.FdSet, e *unix.FdSet, timeout *unix.Timeval) error {
-	return unix.Select(nfd, r, w, e, timeout)
+	_, err := unix.Select(nfd, r, w, e, timeout)
+	return err
 }


### PR DESCRIPTION
This lets us include the package on those platforms in a
followup commit where we split out a conn package from device.
It also lets us run `go test ./...` when developing on macOS.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>