### PR TITLE
wintun: split error message for create vs open namespace.

### DIFF
--- a/tun/wintun/namespace_windows.go
+++ b/tun/wintun/namespace_windows.go
@@ -59,9 +59,12 @@ func initializeNamespace() error {
 			if err == windows.ERROR_PATH_NOT_FOUND {
 				continue
 			}
+			if err != nil {
+				return fmt.Errorf("OpenPrivateNamespace failed: %v", err)
+			}
 		}
 		if err != nil {
-			return fmt.Errorf("Create/OpenPrivateNamespace failed: %v", err)
+			return fmt.Errorf("CreatePrivateNamespace failed: %v", err)
 		}
 		break
 	}


### PR DESCRIPTION
For upstreaming.