### PR TITLE
device: fix trie corruption during incremental reconfiguration.

### DIFF
--- a/device/config.go
+++ b/device/config.go
@@ -149,6 +149,14 @@ func (device *Device) Reconfig(cfg *wgcfg.Config) (err error) {
 		peer.Unlock()
 
 		device.allowedips.RemoveByPeer(peer)
+		// DANGER: allowedIP is a value type. Its contents (the IP and
+		// Mask) are overwritten on every iteration through the
+		// loop. If you try to pass references into other things, the
+		// content of those references will mutate in surprising ways.
+		//
+		// It's safe to use allowedIP.IP.IP(), because that function
+		// makes a copy of the bytes. Be very careful when doing other
+		// things to allowedIP.
 		for _, allowedIP := range p.AllowedIPs {
 			ones := uint(allowedIP.Mask)
 			ip := allowedIP.IP.IP()

--- a/wgcfg/ip.go
+++ b/wgcfg/ip.go
@@ -16,7 +16,10 @@ type IP struct {
 
 func (ip IP) String() string { return net.IP(ip.Addr[:]).String() }
 
-func (ip *IP) IP() net.IP { return net.IP(ip.Addr[:]) }
+// IP converts ip into a standard library net.IP. The address bytes
+// are copied, so the returned net.IP shares no state with the
+// original IP.
+func (ip *IP) IP() net.IP { return append(net.IP(nil), ip.Addr[:]...) }
 func (ip *IP) Is6() bool  { return !ip.Is4() }
 func (ip *IP) Is4() bool {
 	return ip.Addr[0] == 0 && ip.Addr[1] == 0 &&


### PR DESCRIPTION
During incremental reconfig, we iterate over a list of wgcfg.CIDR.
This makes the loop variable contain IP bytes that get clobbered on
every loop iteration. We then passed a slice of those IP bytes into
the trie for storage. So, any time we iterated through the loop more
than once (i.e. any node advertising subnet routes), we corrupted
the allowedips trie.

Signed-off-by: David Anderson <danderson@tailscale.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/wireguard-go/11)
<!-- Reviewable:end -->
