### PR TITLE
tai64n: test using a deterministic API

### DIFF
--- a/tai64n/tai64n.go
+++ b/tai64n/tai64n.go
@@ -17,14 +17,17 @@ const whitenerMask = uint32(0x1000000 - 1)
 
 type Timestamp [TimestampSize]byte
 
-func Now() Timestamp {
+func stamp(t time.Time) Timestamp {
 	var tai64n Timestamp
-	now := time.Now()
-	secs := base + uint64(now.Unix())
-	nano := uint32(now.Nanosecond()) &^ whitenerMask
+	secs := base + uint64(t.Unix())
+	nano := uint32(t.Nanosecond()) &^ whitenerMask
 	binary.BigEndian.PutUint64(tai64n[:], secs)
 	binary.BigEndian.PutUint32(tai64n[8:], nano)
 	return tai64n
+}
+
+func Now() Timestamp {
+	return stamp(time.Now())
 }
 
 func (t1 Timestamp) After(t2 Timestamp) bool {

--- a/tai64n/tai64n_test.go
+++ b/tai64n/tai64n_test.go
@@ -10,21 +10,31 @@ import (
 	"time"
 )
 
-/* Testing the essential property of the timestamp
- * as used by WireGuard.
- */
+// Test that timestamps are monotonic as required by Wireguard and that
+// nanosecond-level information is whitened to prevent side channel attacks.
 func TestMonotonic(t *testing.T) {
-	old := Now()
-	for i := 0; i < 50; i++ {
-		next := Now()
-		if next.After(old) {
-			t.Error("Whitening insufficient")
-		}
-		time.Sleep(time.Duration(whitenerMask)/time.Nanosecond + 1)
-		next = Now()
-		if !next.After(old) {
-			t.Error("Not monotonically increasing on whitened nano-second scale")
-		}
-		old = next
+	startTime := time.Unix(0, 123456789) // a nontrivial bit pattern
+	// Whitening should reduce timestamp granularity
+	// to more than 10 but fewer than 20 milliseconds.
+	tests := []struct {
+		name      string
+		t1, t2    time.Time
+		wantAfter bool
+	}{
+		{"after_10_ns", startTime, startTime.Add(10 * time.Nanosecond), false},
+		{"after_10_us", startTime, startTime.Add(10 * time.Microsecond), false},
+		{"after_1_ms", startTime, startTime.Add(time.Millisecond), false},
+		{"after_10_ms", startTime, startTime.Add(10 * time.Millisecond), false},
+		{"after_20_ms", startTime, startTime.Add(20 * time.Millisecond), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts1, ts2 := stamp(tt.t1), stamp(tt.t2)
+			got := ts2.After(ts1)
+			if got != tt.wantAfter {
+				t.Errorf("after = %v; want %v", got, tt.wantAfter)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`tai64n/tai64n_test.go` is currently flaky due to an assumption of no preemption:
```go
for i := 0; i < 50; i++ {
	next := Now()  // (2)
	if next.After(old) {
		t.Error("Whitening insufficient")
	}
	time.Sleep(time.Duration(whitenerMask)/time.Nanosecond + 1)
	next = Now() // (1)
	if !next.After(old) {
			// ...
	}
	old = next
}
```
It is assumed that two consecutive calls to `tai64n.Now()` (which whitens the returned timestamp) will return the same value, but they may not: if (1) was close to overflowing the whitened region, then the time interval in which Now() will return the same value again is proportionately small. If e.g. the test process is scheduled away before (2), this interval can pass and the test's assumption will be violated.

It appears that `tai64n` does not intend to provide the strong guarantee that the interval in which calls to `Now()` return the same value is fixed regardless of the nanosecond offset of the first call, instead simply decreasing the granularity to prevent information leakage (ref tailscale/wireguard-go@a5ca02d: `Avoid being too precise of a time oracle.`). Therefore, it seems reasonable to keep the API the same and make the test deterministic instead.

This fixes tailscale/tailscale#174.