### PR TITLE
device/device: remove packet filtering.

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -83,21 +83,6 @@ func TestTwoDevicePing(t *testing.T) {
 			t.Error("return ping did not transit")
 		}
 	})
-
-	t.Run("ping 1.0.0.2 via SendPacket", func(t *testing.T) {
-		msg1to2 := tuntest.Ping(net.ParseIP("1.0.0.2"), net.ParseIP("1.0.0.1"))
-		if err := dev1.SendPacket(msg1to2); err != nil {
-			t.Fatal(err)
-		}
-		select {
-		case msgRecv := <-tun2.Inbound:
-			if !bytes.Equal(msg1to2, msgRecv) {
-				t.Error("return ping did not transit correctly")
-			}
-		case <-time.After(300 * time.Millisecond):
-			t.Error("return ping did not transit")
-		}
-	})
 }
 
 func TestSimultaneousHandshake(t *testing.T) {

--- a/device/receive.go
+++ b/device/receive.go
@@ -8,7 +8,6 @@ package device
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"net"
 	"strconv"
 	"sync"
@@ -230,8 +229,6 @@ func (device *Device) RoutineReceiveIncoming(IP int, bind conn.Bind) {
 	}
 }
 
-var FilteredErr = errors.New("packet dropped by administrative filter")
-
 func (device *Device) RoutineDecryption() {
 
 	var nonce [chacha20poly1305.NonceSize]byte
@@ -288,15 +285,6 @@ func (device *Device) RoutineDecryption() {
 				content,
 				nil,
 			)
-			device.filterLock.Lock()
-			fp := device.filterIn
-			device.filterLock.Unlock()
-			if err == nil && fp != nil {
-				response := fp(elem.packet)
-				if response != FilterAccept {
-					err = FilteredErr
-				}
-			}
 			if err != nil {
 				elem.Drop()
 				device.PutMessageBuffer(elem.buffer)


### PR DESCRIPTION
This is the other leg of tailscale/tailscale#358 (and, as such, should be merged after it). This change brings us closer to upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/wireguard-go/15)
<!-- Reviewable:end -->
