### PR TITLE
device: fix locking in config and send

### DIFF
--- a/device/config.go
+++ b/device/config.go
@@ -14,7 +14,7 @@ import (
 func (device *Device) Config() *wgcfg.Config {
 	// Lock everything.
 	device.net.Lock()
-	device.net.Unlock()
+	defer device.net.Unlock()
 	device.staticIdentity.Lock()
 	defer device.staticIdentity.Unlock()
 	device.peers.Lock()

--- a/device/config.go
+++ b/device/config.go
@@ -12,16 +12,16 @@ import (
 )
 
 func (device *Device) Config() *wgcfg.Config {
-	device.net.Lock()
+	device.net.RLock()
 	listenPort := device.net.port
-	device.net.Unlock()
+	device.net.RUnlock()
 
-	device.staticIdentity.Lock()
+	device.staticIdentity.RLock()
 	privateKey := device.staticIdentity.privateKey
-	device.staticIdentity.Unlock()
+	device.staticIdentity.RUnlock()
 
-	device.peers.Lock()
-	defer device.peers.Unlock()
+	device.peers.RLock()
+	defer device.peers.RUnlock()
 
 	cfg := &wgcfg.Config{
 		PrivateKey: privateKey,

--- a/device/config.go
+++ b/device/config.go
@@ -21,13 +21,14 @@ func (device *Device) Config() *wgcfg.Config {
 	device.staticIdentity.RUnlock()
 
 	device.peers.RLock()
-	defer device.peers.RUnlock()
+	keyMap := device.peers.keyMap
+	device.peers.RUnlock()
 
 	cfg := &wgcfg.Config{
 		PrivateKey: privateKey,
 		ListenPort: listenPort,
 	}
-	for _, peer := range device.peers.keyMap {
+	for _, peer := range keyMap {
 		peer.RLock()
 		p := wgcfg.Peer{
 			PublicKey:           peer.handshake.remoteStatic,

--- a/device/config.go
+++ b/device/config.go
@@ -12,17 +12,20 @@ import (
 )
 
 func (device *Device) Config() *wgcfg.Config {
-	// Lock everything.
 	device.net.Lock()
-	defer device.net.Unlock()
+	listenPort := device.net.port
+	device.net.Unlock()
+
 	device.staticIdentity.Lock()
-	defer device.staticIdentity.Unlock()
+	privateKey := device.staticIdentity.privateKey
+	device.staticIdentity.Unlock()
+
 	device.peers.Lock()
 	defer device.peers.Unlock()
 
 	cfg := &wgcfg.Config{
-		PrivateKey: device.staticIdentity.privateKey,
-		ListenPort: device.net.port,
+		PrivateKey: privateKey,
+		ListenPort: listenPort,
 	}
 	for _, peer := range device.peers.keyMap {
 		peer.RLock()

--- a/device/send.go
+++ b/device/send.go
@@ -145,13 +145,14 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	peer.handshake.mutex.Unlock()
 
 	peer.RLock()
-	if peer.endpoint == nil {
-		peer.RUnlock()
+	endpoint := peer.endpoint
+	peer.RUnlock()
+
+	if endpoint == nil {
 		return errors.New("no peer endpoint; skipped")
 	}
 
-	peer.device.log.Debug.Printf("%v - %v Send handshake init %v", peer, peer.device, peer.endpoint)
-	peer.RUnlock()
+	peer.device.log.Debug.Printf("%v - %v Send handshake init %v", peer, peer.device, endpoint)
 
 	msg, err := peer.device.CreateMessageInitiation(peer)
 	if err != nil {

--- a/device/send.go
+++ b/device/send.go
@@ -144,11 +144,14 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	peer.handshake.lastSentHandshake = time.Now()
 	peer.handshake.mutex.Unlock()
 
+	peer.RLock()
 	if peer.endpoint == nil {
+		peer.RUnlock()
 		return errors.New("no peer endpoint; skipped")
 	}
 
 	peer.device.log.Debug.Printf("%v - %v Send handshake init %v", peer, peer.device, peer.endpoint)
+	peer.RUnlock()
 
 	msg, err := peer.device.CreateMessageInitiation(peer)
 	if err != nil {

--- a/device/send.go
+++ b/device/send.go
@@ -145,6 +145,7 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	peer.handshake.mutex.Unlock()
 
 	peer.RLock()
+	device := peer.device
 	endpoint := peer.endpoint
 	peer.RUnlock()
 
@@ -152,7 +153,7 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 		return errors.New("no peer endpoint; skipped")
 	}
 
-	peer.device.log.Debug.Printf("%v - %v Send handshake init %v", peer, peer.device, endpoint)
+	device.log.Debug.Printf("%v - %v Send handshake init %v", peer, device, endpoint)
 
 	msg, err := peer.device.CreateMessageInitiation(peer)
 	if err != nil {


### PR DESCRIPTION
This is the Wireguard half of the changes necessary to eliminate races in `ipn/e2e_test.go`.

Updates tailscale/corp#255.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/wireguard-go/16)
<!-- Reviewable:end -->
