### PR TITLE
device: add Device.IpcGetOperationFiltered and change HandshakeDone callback

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -6,7 +6,6 @@
 package device
 
 import (
-	"net"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -30,7 +29,7 @@ type Device struct {
 	isUp           AtomicBool // device is (going) up
 	isClosed       AtomicBool // device is closed? (acting as guard)
 	log            *Logger
-	handshakeDone  func(peerKey wgcfg.Key, allowedIPs []net.IPNet)
+	handshakeDone  func(peerKey wgcfg.Key, peer *Peer, allowedIPs *AllowedIPs)
 	skipBindUpdate bool
 	createBind     func(uport uint16, device *Device) (conn.Bind, uint16, error)
 	createEndpoint func(key [32]byte, s string) (conn.Endpoint, error)
@@ -295,8 +294,7 @@ type DeviceOptions struct {
 	UnexpectedIP func(key *wgcfg.Key, ip wgcfg.IP)
 
 	// HandshakeDone is called every time we complete a peer handshake.
-	// TODO(crawshaw): send the *Peer parameter here?
-	HandshakeDone func(peerKey wgcfg.Key, allowedIPs []net.IPNet)
+	HandshakeDone func(peerKey wgcfg.Key, peer *Peer, allowedIPs *AllowedIPs)
 
 	CreateEndpoint func(key [32]byte, s string) (conn.Endpoint, error)
 	CreateBind     func(uport uint16) (conn.Bind, uint16, error)

--- a/device/send.go
+++ b/device/send.go
@@ -346,8 +346,7 @@ func (peer *Peer) handshakeDoneCallback() {
 	key := peer.handshake.remoteStatic
 	peer.RUnlock()
 
-	allowedIPs := peer.device.allowedips.EntriesForPeer(peer)
-	peer.device.handshakeDone(key, allowedIPs)
+	peer.device.handshakeDone(key, peer, &peer.device.allowedips)
 }
 
 /* Queues packets when there is no handshake.

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -31,7 +31,17 @@ func (s IPCError) ErrorCode() int64 {
 	return s.int64
 }
 
+// IPCGetFilter are options to control which fields are omitted from Device.IpcGetOperationFiltered.
+type IPCGetFilter struct {
+	// FilterAllowedIPs controls whether AllowedIPs are omitted in the output.
+	FilterAllowedIPs bool
+}
+
 func (device *Device) IpcGetOperation(socket *bufio.Writer) *IPCError {
+	return device.IpcGetOperationFiltered(socket, IPCGetFilter{})
+}
+
+func (device *Device) IpcGetOperationFiltered(socket *bufio.Writer, filter IPCGetFilter) *IPCError {
 	lines := make([]string, 0, 100)
 	send := func(line string) {
 		lines = append(lines, line)
@@ -87,10 +97,11 @@ func (device *Device) IpcGetOperation(socket *bufio.Writer) *IPCError {
 			send(fmt.Sprintf("rx_bytes=%d", atomic.LoadUint64(&peer.stats.rxBytes)))
 			send(fmt.Sprintf("persistent_keepalive_interval=%d", peer.persistentKeepaliveInterval))
 
-			for _, ip := range device.allowedips.EntriesForPeer(peer) {
-				send("allowed_ip=" + ip.String())
+			if !filter.FilterAllowedIPs {
+				for _, ip := range device.allowedips.EntriesForPeer(peer) {
+					send("allowed_ip=" + ip.String())
+				}
 			}
-
 		}
 	}()
 


### PR DESCRIPTION
Both changes enable preventing calls to AllowedIPs.EntriesForPeer when
unneeded.

We've found AllowedIPs to be a hot path.

Signed-off-by: Brad Fitzpatrick <brad@danga.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/wireguard-go/19)
<!-- Reviewable:end -->
