### PR TITLE
device: avoid unnecessary AllowedIPs.RemoveByPeer calls during Reconfig

### DIFF
--- a/device/peer.go
+++ b/device/peer.go
@@ -42,6 +42,7 @@ type Peer struct {
 	handshake                   Handshake
 	device                      *Device
 	endpoint                    conn.Endpoint
+	allowedIPs                  []wgcfg.CIDR
 	persistentKeepaliveInterval uint16
 
 	timers struct {


### PR DESCRIPTION
Usually, a peer's AllowedIPs don't change during reconfig, so no need to
call AllowedIPs.RemoveByPeer (which is very expensive currently; see
https://github.com/WireGuard/wireguard-go/pull/36).

Instead, remember what it was previously.

Also, one unrelated minor optimization to reduce some map garbage
during reconfig when endpoints don't change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tailscale/wireguard-go/20)
<!-- Reviewable:end -->
