### PR TITLE
all: convert []wgcfg.Endpoint to a string

### DIFF
--- a/conn/conn.go
+++ b/conn/conn.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"net"
 	"strings"
-
-	"github.com/tailscale/wireguard-go/wgcfg"
 )
 
 // A Bind listens on a port for both IPv6 and IPv4 UDP traffic.
@@ -83,7 +81,7 @@ type Endpoint interface {
 	DstIP() net.IP
 	SrcIP() net.IP
 	UpdateDst(addr *net.UDPAddr) error
-	Addrs() []wgcfg.Endpoint
+	Addrs() string // comma-separated host/port pairs: "1.2.3.4:56,[::]:80"
 }
 
 func parseEndpoint(s string) (*net.UDPAddr, error) {

--- a/conn/conn_default.go
+++ b/conn/conn_default.go
@@ -10,9 +10,8 @@ package conn
 import (
 	"net"
 	"os"
+	"strconv"
 	"syscall"
-
-	"github.com/tailscale/wireguard-go/wgcfg"
 )
 
 /* This code is meant to be a temporary solution
@@ -77,11 +76,8 @@ func (e *NativeEndpoint) UpdateDst(dst *net.UDPAddr) error {
 	return nil
 }
 
-func (e *NativeEndpoint) Addrs() []wgcfg.Endpoint {
-	return []wgcfg.Endpoint{{
-		Host: e.IP.String(),
-		Port: uint16(e.Port),
-	}}
+func (e *NativeEndpoint) Addrs() string {
+	return net.JoinHostPort(e.IP.String(), strconv.Itoa(e.Port))
 }
 
 func listenNet(network string, port int) (*net.UDPConn, int, error) {

--- a/conn/conn_linux.go
+++ b/conn/conn_linux.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/tailscale/wireguard-go/wgcfg"
 	"golang.org/x/sys/unix"
 )
 
@@ -60,18 +59,14 @@ func (endpoint *NativeEndpoint) dst6() *unix.SockaddrInet6 {
 	return (*unix.SockaddrInet6)(unsafe.Pointer(&endpoint.dst[0]))
 }
 
-func (e *NativeEndpoint) Addrs() []wgcfg.Endpoint {
-	port := uint16(0)
+func (e *NativeEndpoint) Addrs() string {
+	var port int
 	if e.isV6 {
-		port = uint16(e.dst6().Port)
+		port = e.dst6().Port
 	} else {
-		port = uint16(e.dst4().Port)
+		port = e.dst4().Port
 	}
-
-	return []wgcfg.Endpoint{{
-		Host: e.DstIP().String(),
-		Port: uint16(port),
-	}}
+	return net.JoinHostPort(e.DstIP().String(), strconv.Itoa(port))
 }
 
 type nativeBind struct {

--- a/device/config_test.go
+++ b/device/config_test.go
@@ -116,10 +116,7 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("device1 modify peer", func(t *testing.T) {
-		cfg1.Peers[0].Endpoints = []wgcfg.Endpoint{{
-			Host: "1.2.3.4",
-			Port: 12345,
-		}}
+		cfg1.Peers[0].Endpoints = "1.2.3.4:12345"
 		if err := device1.Reconfig(cfg1); err != nil {
 			t.Fatal(err)
 		}
@@ -127,9 +124,7 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("device1 replace endpoint", func(t *testing.T) {
-		cfg1.Peers[0].Endpoints = []wgcfg.Endpoint{
-			{Host: "1.1.1.1", Port: 123},
-		}
+		cfg1.Peers[0].Endpoints = "1.1.1.1:123"
 		if err := device1.Reconfig(cfg1); err != nil {
 			t.Fatal(err)
 		}

--- a/wgcfg/config.go
+++ b/wgcfg/config.go
@@ -7,9 +7,6 @@
 package wgcfg
 
 import (
-	"fmt"
-	"strings"
-
 	"inet.af/netaddr"
 )
 
@@ -28,24 +25,8 @@ type Peer struct {
 	PublicKey           Key
 	PresharedKey        SymmetricKey
 	AllowedIPs          []netaddr.IPPrefix
-	Endpoints           []Endpoint
+	Endpoints           string // comma-separated host/port pairs: "1.2.3.4:56,[::]:80"
 	PersistentKeepalive uint16
-}
-
-type Endpoint struct {
-	Host string
-	Port uint16
-}
-
-func (e *Endpoint) String() string {
-	if strings.IndexByte(e.Host, ':') > 0 {
-		return fmt.Sprintf("[%s]:%d", e.Host, e.Port)
-	}
-	return fmt.Sprintf("%s:%d", e.Host, e.Port)
-}
-
-func (e *Endpoint) IsEmpty() bool {
-	return len(e.Host) == 0
 }
 
 // Copy makes a deep copy of Config.
@@ -72,9 +53,6 @@ func (peer Peer) Copy() Peer {
 	res := peer
 	if res.AllowedIPs != nil {
 		res.AllowedIPs = append([]netaddr.IPPrefix{}, res.AllowedIPs...)
-	}
-	if res.Endpoints != nil {
-		res.Endpoints = append([]Endpoint{}, res.Endpoints...)
 	}
 	return res
 }

--- a/wgcfg/parser_test.go
+++ b/wgcfg/parser_test.go
@@ -87,42 +87,42 @@ func TestFromWgQuick(t *testing.T) {
 
 		lenTest(t, conf.Peers, 3)
 		lenTest(t, conf.Peers[0].AllowedIPs, 2)
-		equal(t, Endpoint{Host: "192.95.5.67", Port: 1234}, conf.Peers[0].Endpoints[0])
+		equal(t, "192.95.5.67:1234", conf.Peers[0].Endpoints)
 		equal(t, "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=", conf.Peers[0].PublicKey.Base64())
 
 		lenTest(t, conf.Peers[1].AllowedIPs, 2)
-		equal(t, Endpoint{Host: "2607:5300:60:6b0::c05f:543", Port: 2468}, conf.Peers[1].Endpoints[0])
+		equal(t, "[2607:5300:60:6b0::c05f:543]:2468", conf.Peers[1].Endpoints)
 		equal(t, "TrMvSoP4jYQlY6RIzBgbssQqY3vxI2Pi+y71lOWWXX0=", conf.Peers[1].PublicKey.Base64())
 		equal(t, uint16(100), conf.Peers[1].PersistentKeepalive)
 
 		lenTest(t, conf.Peers[2].AllowedIPs, 1)
-		equal(t, Endpoint{Host: "test.wireguard.com", Port: 18981}, conf.Peers[2].Endpoints[0])
+		equal(t, "test.wireguard.com:18981", conf.Peers[2].Endpoints)
 		equal(t, "gN65BkIKy1eCE9pP1wdc8ROUtkHLF2PfAqYdyYBz6EA=", conf.Peers[2].PublicKey.Base64())
 		equal(t, "TrMvSoP4jYQlY6RIzBgbssQqY3vxI2Pi+y71lOWWXX0=", conf.Peers[2].PresharedKey.Base64())
 	}
 }
 
 func TestParseEndpoint(t *testing.T) {
-	_, err := parseEndpoint("[192.168.42.0:]:51880")
+	_, _, err := parseEndpoint("[192.168.42.0:]:51880")
 	if err == nil {
 		t.Error("Error was expected")
 	}
-	e, err := parseEndpoint("192.168.42.0:51880")
+	host, port, err := parseEndpoint("192.168.42.0:51880")
 	if noError(t, err) {
-		equal(t, "192.168.42.0", e.Host)
-		equal(t, uint16(51880), e.Port)
+		equal(t, "192.168.42.0", host)
+		equal(t, uint16(51880), port)
 	}
-	e, err = parseEndpoint("test.wireguard.com:18981")
+	host, port, err = parseEndpoint("test.wireguard.com:18981")
 	if noError(t, err) {
-		equal(t, "test.wireguard.com", e.Host)
-		equal(t, uint16(18981), e.Port)
+		equal(t, "test.wireguard.com", host)
+		equal(t, uint16(18981), port)
 	}
-	e, err = parseEndpoint("[2607:5300:60:6b0::c05f:543]:2468")
+	host, port, err = parseEndpoint("[2607:5300:60:6b0::c05f:543]:2468")
 	if noError(t, err) {
-		equal(t, "2607:5300:60:6b0::c05f:543", e.Host)
-		equal(t, uint16(2468), e.Port)
+		equal(t, "2607:5300:60:6b0::c05f:543", host)
+		equal(t, uint16(2468), port)
 	}
-	_, err = parseEndpoint("[::::::invalid:18981")
+	_, _, err = parseEndpoint("[::::::invalid:18981")
 	if err == nil {
 		t.Error("Error was expected")
 	}


### PR DESCRIPTION
This is less type safe, but it eliminates another
widely used wgcfg type. There's no good place to put
the Endpoint type as we migrate code across modules.

After this, the only remaining wgcfg types used
in this module are in device/config{_test}.go.

