### PR TITLE
device: revert UpdateDst callback and related code

### DIFF
--- a/conn/conn.go
+++ b/conn/conn.go
@@ -28,17 +28,15 @@ type Bind interface {
 	//
 	// It reports the number of bytes read, n,
 	// the packet source address ep,
-	// the UDP address addr,
 	// and any error.
-	ReceiveIPv6(buff []byte) (n int, ep Endpoint, addr *net.UDPAddr, err error)
+	ReceiveIPv6(buff []byte) (n int, ep Endpoint, err error)
 
 	// ReceiveIPv4 reads an IPv4 UDP packet into b.
 	//
 	// It reports the number of bytes read, n,
 	// the packet source address ep,
-	// the UDP address addr,
 	// and any error.
-	ReceiveIPv4(b []byte) (n int, ep Endpoint, addr *net.UDPAddr, err error)
+	ReceiveIPv4(b []byte) (n int, ep Endpoint, err error)
 
 	// Send writes a packet b to address ep.
 	Send(b []byte, ep Endpoint) error
@@ -80,7 +78,6 @@ type Endpoint interface {
 	DstToBytes() []byte  // used for mac2 cookie calculations
 	DstIP() net.IP
 	SrcIP() net.IP
-	UpdateDst(addr *net.UDPAddr) error
 	Addrs() string // comma-separated host/port pairs: "1.2.3.4:56,[::]:80"
 }
 

--- a/conn/conn_default.go
+++ b/conn/conn_default.go
@@ -50,10 +50,6 @@ func (e *NativeEndpoint) SrcIP() net.IP {
 
 func (e *NativeEndpoint) DstToBytes() []byte {
 	addr := (*net.UDPAddr)(e)
-	return addrToBytes(addr)
-}
-
-func addrToBytes(addr *net.UDPAddr) []byte {
 	out := addr.IP.To4()
 	if out == nil {
 		out = addr.IP
@@ -69,11 +65,6 @@ func (e *NativeEndpoint) DstToString() string {
 
 func (e *NativeEndpoint) SrcToString() string {
 	return ""
-}
-
-func (e *NativeEndpoint) UpdateDst(dst *net.UDPAddr) error {
-	*e = (NativeEndpoint)(*dst)
-	return nil
 }
 
 func (e *NativeEndpoint) Addrs() string {
@@ -147,23 +138,23 @@ func (bind *nativeBind) Close() error {
 
 func (bind *nativeBind) LastMark() uint32 { return 0 }
 
-func (bind *nativeBind) ReceiveIPv4(buff []byte) (int, Endpoint, *net.UDPAddr, error) {
+func (bind *nativeBind) ReceiveIPv4(buff []byte) (int, Endpoint, error) {
 	if bind.ipv4 == nil {
-		return 0, nil, nil, syscall.EAFNOSUPPORT
+		return 0, nil, syscall.EAFNOSUPPORT
 	}
-	n, addr, err := bind.ipv4.ReadFromUDP(buff)
-	if addr != nil {
-		addr.IP = addr.IP.To4()
+	n, endpoint, err := bind.ipv4.ReadFromUDP(buff)
+	if endpoint != nil {
+		endpoint.IP = endpoint.IP.To4()
 	}
-	return n, (*NativeEndpoint)(addr), addr, err
+	return n, (*NativeEndpoint)(endpoint), err
 }
 
-func (bind *nativeBind) ReceiveIPv6(buff []byte) (int, Endpoint, *net.UDPAddr, error) {
+func (bind *nativeBind) ReceiveIPv6(buff []byte) (int, Endpoint, error) {
 	if bind.ipv6 == nil {
-		return 0, nil, nil, syscall.EAFNOSUPPORT
+		return 0, nil, syscall.EAFNOSUPPORT
 	}
-	n, addr, err := bind.ipv6.ReadFromUDP(buff)
-	return n, (*NativeEndpoint)(addr), addr, err
+	n, endpoint, err := bind.ipv6.ReadFromUDP(buff)
+	return n, (*NativeEndpoint)(endpoint), err
 }
 
 func (bind *nativeBind) Send(buff []byte, endpoint Endpoint) error {

--- a/device/allowedips.go
+++ b/device/allowedips.go
@@ -249,11 +249,3 @@ func (table *AllowedIPs) LookupIPv6(address []byte) *Peer {
 	defer table.mutex.RUnlock()
 	return table.IPv6.lookup(address)
 }
-
-func (table *AllowedIPs) LookupIP(a net.IP) *Peer {
-	if a.To4() != nil {
-		return table.LookupIPv4(a)
-	} else {
-		return table.LookupIPv6(a)
-	}
-}

--- a/device/peer.go
+++ b/device/peer.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -309,20 +308,11 @@ func (peer *Peer) Stop() {
 	peer.ZeroAndFlushAll()
 }
 
-func (peer *Peer) SetEndpointAddress(addr *net.UDPAddr) {
+func (peer *Peer) SetEndpointFromPacket(endpoint conn.Endpoint) {
 	if peer.disableRoaming {
 		return
 	}
-	if p := peer.device.allowedips.LookupIP(addr.IP); p != nil {
-		return
-	}
-
 	peer.Lock()
-	if peer.endpoint != nil {
-		err := peer.endpoint.UpdateDst(addr)
-		if err != nil {
-			peer.device.log.Debug.Printf("%v - SetEndpointAddress: %v", peer, err)
-		}
-	}
+	peer.endpoint = endpoint
 	peer.Unlock()
 }

--- a/device/send.go
+++ b/device/send.go
@@ -230,7 +230,7 @@ func (peer *Peer) SendHandshakeResponse() error {
 
 func (device *Device) SendHandshakeCookie(initiatingElem *QueueHandshakeElement) error {
 
-	device.log.Debug.Println("Sending cookie response for denied handshake message for", initiatingElem.addr)
+	device.log.Debug.Println("Sending cookie response for denied handshake message for", initiatingElem.endpoint.DstToString())
 
 	sender := binary.LittleEndian.Uint32(initiatingElem.packet[4:8])
 	reply, err := device.cookieChecker.CreateReply(initiatingElem.packet, sender, initiatingElem.endpoint.DstToBytes())


### PR DESCRIPTION
This is a revert of three commits in our fork:

Revert "device: do not call UpdateDst on nil endpoints"
This reverts commit eb5cf120e378cd96ae97d6034af4330176173613.

Revert "[HACK] peer: Don't allow UpdateDst() to an endpoint in our list of routes."
This reverts commit 5064d11a19742bdbf8cb299aa9d5447af64d38f7.

Revert "[Tailscale] device: pass around *net.UDPAddr in addition to Endpoint."
This reverts commit 9e373c18044cdf0fad400e890948c4e274816cbc.