### PR TITLE
Revert "Revert "device: send first few handshake init retries faster""

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -94,14 +94,14 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	}
 
 	peer.handshake.mutex.RLock()
-	if time.Since(peer.handshake.lastSentHandshake) < RekeyTimeout {
+	if !isRetry && time.Since(peer.handshake.lastSentHandshake) < RekeyTimeout {
 		peer.handshake.mutex.RUnlock()
 		return nil
 	}
 	peer.handshake.mutex.RUnlock()
 
 	peer.handshake.mutex.Lock()
-	if time.Since(peer.handshake.lastSentHandshake) < RekeyTimeout {
+	if !isRetry && time.Since(peer.handshake.lastSentHandshake) < RekeyTimeout {
 		peer.handshake.mutex.Unlock()
 		return nil
 	}

--- a/device/timers.go
+++ b/device/timers.go
@@ -178,7 +178,12 @@ func (peer *Peer) timersAnyAuthenticatedPacketReceived() {
 /* Should be called after a handshake initiation message is sent. */
 func (peer *Peer) timersHandshakeInitiated() {
 	if peer.timersActive() {
-		peer.timers.retransmitHandshake.Mod(RekeyTimeout + time.Millisecond*time.Duration(rand.Int31n(RekeyTimeoutJitterMaxMs)))
+		timeout := RekeyTimeout
+		if atomic.LoadUint32(&peer.timers.handshakeAttempts) == 0 {
+			// Let the first retry be fast.
+			timeout = time.Second
+		}
+		peer.timers.retransmitHandshake.Mod(timeout + time.Millisecond*time.Duration(rand.Int31n(RekeyTimeoutJitterMaxMs)))
 	}
 }
 


### PR DESCRIPTION
This reverts commit 00ef1f2e8a1dfc7b1be5fe19501d6d0326273241,
which was a revert of commit 2a61e94dc4a80b26c161c85efd30eb78c0770556.

Without this, the tailscale.com/wgengine/magicsock.TestTwoDevice test is flaky.

I believe that this is the fix for https://github.com/tailscale/tailscale/issues/1277, once the go.mod is updated there. (Local indications are good, but don't know 100% for sure until the CI gets its hands on it.)