### PR TITLE
device: move Logger out of DeviceOptions

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -158,7 +158,7 @@ func genTestPair(tb testing.TB) (pair testPair) {
 		if _, ok := tb.(*testing.B); ok && !testing.Verbose() {
 			level = LogLevelError
 		}
-		p.dev = NewDevice(p.tun.TUN(), &DeviceOptions{Logger: NewLogger(level, fmt.Sprintf("dev%d: ", i))})
+		p.dev = NewDevice(p.tun.TUN(), NewLogger(level, fmt.Sprintf("dev%d: ", i)))
 		if err := p.dev.IpcSet(cfg[i]); err != nil {
 			tb.Errorf("failed to configure device %d: %v", i, err)
 			p.dev.Close()
@@ -332,7 +332,7 @@ func randDevice(t *testing.T) *Device {
 	}
 	tun := newDummyTUN("dummy")
 	logger := NewLogger(LogLevelError, "")
-	device := NewDevice(tun, &DeviceOptions{Logger: logger})
+	device := NewDevice(tun, logger)
 	device.SetPrivateKey(sk)
 	return device
 }

--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func main() {
 		return
 	}
 
-	device := device.NewDevice(tun, &device.DeviceOptions{Logger: logger})
+	device := device.NewDevice(tun, logger)
 
 	logger.Verbosef("Device started")
 

--- a/main_windows.go
+++ b/main_windows.go
@@ -47,7 +47,7 @@ func main() {
 		os.Exit(ExitSetupFailed)
 	}
 
-	device := device.NewDevice(tun, &device.DeviceOptions{Logger: logger})
+	device := device.NewDevice(tun, logger)
 	err = device.Up()
 	if err != nil {
 		logger.Errorf("Failed to bring up device: %v", err)


### PR DESCRIPTION
And make DeviceOptions optional.
And assume that DeviceOptions are all-or-none.
And remove an unnecessary argument from CreateBind.

These change reduces merge pain by making call sites
look more like upstream call sites, and by removing
unnecessary complexity.
