### PR TITLE
device: disable route listener.

### DIFF
--- a/device/sticky_linux.go
+++ b/device/sticky_linux.go
@@ -26,6 +26,10 @@ import (
 )
 
 func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, error) {
+	// NOTE(Tailscale): we don't use this; we use
+	// https://github.com/tailscale/tailscale/wgengine/{magicsock,monitor}
+	return nil, nil
+
 	netlinkSock, err := createNetlinkRouteSocket()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Workaround to support Cloud Run, which has no AF_NETLINK
RTMGRP support.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>