### PR TITLE
device: make CreateEndpoint have only one param

### DIFF
--- a/device/uapi.go
+++ b/device/uapi.go
@@ -330,10 +330,14 @@ func (device *Device) handlePeerLine(peer *ipcSetPeer, key, value string) error 
 
 	case "endpoint":
 		device.log.Verbosef("%v - UAPI: Updating endpoint", peer.Peer)
-		peer.handshake.mutex.Lock()
-		key := peer.handshake.remoteStatic
-		peer.handshake.mutex.Unlock()
-		endpoint, err := device.createEndpoint(key, value)
+		s := value
+		if device.prependKeyToEndpoint {
+			peer.handshake.mutex.Lock()
+			key := peer.handshake.remoteStatic
+			peer.handshake.mutex.Unlock()
+			s = string(key[:]) + s
+		}
+		endpoint, err := device.createEndpoint(s)
 		if err != nil {
 			return ipcErrorf(ipc.IpcErrorInvalid, "failed to set endpoint %v: %w", value, err)
 		}


### PR DESCRIPTION
When opts are set, concatenate the public key and the addrs.
Making the function signature of DeviceOptions.createEndpoint match
that of conn.CreateEndpoint makes merges with upstream easier.
This is ugly, but it is also temporary.
I plan to embed the public key in the addr in a more principled
way in the future on the Tailscale side.
This just unblocks me while I work on other aspects
of merging and fork removal.

While we're here, make skipBindUpdate implicit as well.
