### PR TITLE
device: remove option to set private_key to zero

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -243,11 +243,8 @@ func (device *Device) SetPrivateKey(sk NoisePrivateKey) error {
 	}
 
 	// remove peers with matching public keys
-	var publicKey NoisePublicKey // allow a zero key here for disabling this device
-	if !sk.IsZero() {
-		publicKey = sk.publicKey()
-	}
 
+	publicKey := sk.publicKey()
 	for key, peer := range device.peers.keyMap {
 		if peer.handshake.remoteStatic.Equals(publicKey) {
 			peer.handshake.mutex.RUnlock()


### PR DESCRIPTION
I traced the code and did not see a way that this could be set to zero. However, the relevant code paths cross network boundaries and meander into a great many places, so I am slightly nervous I may have missed something.
