### PR TITLE
RoutineReceiveIncoming: print errors that cause the goroutine to exit.

### DIFF
--- a/device/receive.go
+++ b/device/receive.go
@@ -95,9 +95,11 @@ func (device *Device) RoutineReceiveIncoming(recv conn.ReceiveFunc) {
 		if err != nil {
 			device.PutMessageBuffer(buffer)
 			if errors.Is(err, net.ErrClosed) {
+				device.log.Errorf("Routine: receive incoming %s - recv closed: %v", recvName, err)
 				return
 			}
 			if neterr, ok := err.(net.Error); ok && !neterr.Temporary() {
+				device.log.Errorf("Routine: receive incoming %s - recv: %v", recvName, err)
 				return
 			}
 			device.log.Errorf("Failed to receive packet: %v", err)


### PR DESCRIPTION
Previously we were silently discarding some categories of error code,
which makes it very hard to trace what's going on.

Updates: tailscale/tailscale#1790

Signed-off-by: Avery Pennarun <apenwarr@tailscale.com>