### PR TITLE
endian: add loong64

### DIFF
--- a/endian/little.go
+++ b/endian/little.go
@@ -1,4 +1,4 @@
-//go:build 386 || amd64 || arm || arm64 || mips64le || mipsle || ppc64le || riscv64 || wasm
+//go:build 386 || amd64 || arm || arm64 || mips64le || mipsle || ppc64le || riscv64 || wasm || loong64
 
 package endian
 


### PR DESCRIPTION
Commented in upstream PR too:
https://github.com/WireGuard/wireguard-go/pull/64/files#r1045140162

Updates tailscale/tailscale#6233
