### PR TITLE
native: drop in github.com/josharian/native

### DIFF
--- a/endian/big.go
+++ b/endian/big.go
@@ -1,8 +1,0 @@
-//go:build mips || mips64 || ppc64 || s390x
-
-package endian
-
-import "encoding/binary"
-
-// Native is the platform's native byte order.
-var Native = binary.LittleEndian

--- a/endian/little.go
+++ b/endian/little.go
@@ -1,8 +1,0 @@
-//go:build 386 || amd64 || arm || arm64 || mips64le || mipsle || ppc64le || riscv64 || wasm || loong64
-
-package endian
-
-import "encoding/binary"
-
-// Native is the platform's native byte order.
-var Native = binary.LittleEndian

--- a/native/doc.go
+++ b/native/doc.go
@@ -1,0 +1,11 @@
+// Package native provides easy access to native byte order.
+//
+// Usage: use native.Endian where you need the native binary.ByteOrder.
+//
+// Please think twice before using this package.
+// It can break program portability.
+// Native byte order is usually not the right answer.
+// This package is a drop-in of github.com/josharian/native, with attribution in
+// the file 'license'. This package will likely be replaced by something similar
+// in the standard library, see https://github.com/golang/go/issues/57237.
+package native

--- a/native/endian_big.go
+++ b/native/endian_big.go
@@ -1,0 +1,14 @@
+//go:build mips || mips64 || ppc64 || s390x
+// +build mips mips64 ppc64 s390x
+
+package native
+
+import "encoding/binary"
+
+// Endian is the encoding/binary.ByteOrder implementation for the
+// current CPU's native byte order.
+var Endian = binary.BigEndian
+
+// IsBigEndian is whether the current CPU's native byte order is big
+// endian.
+const IsBigEndian = true

--- a/native/endian_generic.go
+++ b/native/endian_generic.go
@@ -1,0 +1,31 @@
+//go:build !mips && !mips64 && !ppc64 && !s390x && !amd64 && !386 && !arm && !arm64 && !loong64 && !mipsle && !mips64le && !ppc64le && !riscv64 && !wasm
+// +build !mips,!mips64,!ppc64,!s390x,!amd64,!386,!arm,!arm64,!loong64,!mipsle,!mips64le,!ppc64le,!riscv64,!wasm
+
+// This file is a fallback, so that package native doesn't break
+// the instant the Go project adds support for a new architecture.
+//
+
+package native
+
+import (
+	"encoding/binary"
+	"log"
+	"runtime"
+	"unsafe"
+)
+
+var Endian binary.ByteOrder
+
+var IsBigEndian bool
+
+func init() {
+	b := uint16(0xff) // one byte
+	if *(*byte)(unsafe.Pointer(&b)) == 0 {
+		Endian = binary.BigEndian
+		IsBigEndian = true
+	} else {
+		Endian = binary.LittleEndian
+		IsBigEndian = false
+	}
+	log.Printf("unrecognized arch %v (%v), please file an issue", runtime.GOARCH, Endian)
+}

--- a/native/endian_little.go
+++ b/native/endian_little.go
@@ -1,0 +1,14 @@
+//go:build amd64 || 386 || arm || arm64 || loong64 || mipsle || mips64le || ppc64le || riscv64 || wasm
+// +build amd64 386 arm arm64 loong64 mipsle mips64le ppc64le riscv64 wasm
+
+package native
+
+import "encoding/binary"
+
+// Endian is the encoding/binary.ByteOrder implementation for the
+// current CPU's native byte order.
+var Endian = binary.LittleEndian
+
+// IsBigEndian is whether the current CPU's native byte order is big
+// endian.
+const IsBigEndian = false

--- a/native/endian_test.go
+++ b/native/endian_test.go
@@ -1,0 +1,20 @@
+package native_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/native"
+)
+
+func TestPrintEndianness(t *testing.T) {
+	t.Logf("native endianness is %v", native.Endian)
+
+	var want binary.ByteOrder = binary.BigEndian
+	if !native.IsBigEndian {
+		want = binary.LittleEndian
+	}
+	if native.Endian != want {
+		t.Errorf("IsBigEndian = %v not consistent with native.Endian = %T", native.IsBigEndian, want)
+	}
+}

--- a/native/license
+++ b/native/license
@@ -1,0 +1,7 @@
+Copyright 2020 Josh Bleecher Snyder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tun/tcp_offload_linux.go
+++ b/tun/tcp_offload_linux.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/endian"
+	"golang.zx2c4.com/wireguard/native"
 )
 
 // virtioNetHdrFlags are defined in the kernel in include/uapi/linux/virtio_net.h.
@@ -52,10 +52,10 @@ func (v *virtioNetHdr) decode(b []byte) error {
 	}
 	v.flags = b[0]
 	v.gsoType = b[1]
-	v.hdrLen = endian.Native.Uint16(b[2:])
-	v.gsoSize = endian.Native.Uint16(b[4:])
-	v.csumStart = endian.Native.Uint16(b[6:])
-	v.csumOffset = endian.Native.Uint16(b[8:])
+	v.hdrLen = native.Endian.Uint16(b[2:])
+	v.gsoSize = native.Endian.Uint16(b[4:])
+	v.csumStart = native.Endian.Uint16(b[6:])
+	v.csumOffset = native.Endian.Uint16(b[8:])
 	return nil
 }
 
@@ -65,10 +65,10 @@ func (v *virtioNetHdr) encode(b []byte) error {
 	}
 	b[0] = v.flags
 	b[1] = v.gsoType
-	endian.Native.PutUint16(b[2:], v.hdrLen)
-	endian.Native.PutUint16(b[4:], v.gsoSize)
-	endian.Native.PutUint16(b[6:], v.csumStart)
-	endian.Native.PutUint16(b[8:], v.csumOffset)
+	native.Endian.PutUint16(b[2:], v.hdrLen)
+	native.Endian.PutUint16(b[4:], v.gsoSize)
+	native.Endian.PutUint16(b[6:], v.csumStart)
+	native.Endian.PutUint16(b[8:], v.csumOffset)
 	return nil
 }
 


### PR DESCRIPTION
This is for the discussion in https://github.com/WireGuard/wireguard-go/pull/64#discussion_r1047501249 and will be cherry-picked onto `tailscale-vector-io-mod-rename` where OSS currently points.