### PR TITLE
all: rename module

### DIFF
--- a/conn/bind_windows.go
+++ b/conn/bind_windows.go
@@ -17,7 +17,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"golang.zx2c4.com/wireguard/conn/winrio"
+	"github.com/tailscale/wireguard-go/conn/winrio"
 )
 
 const (

--- a/conn/bindtest/bindtest.go
+++ b/conn/bindtest/bindtest.go
@@ -12,7 +12,7 @@ import (
 	"net/netip"
 	"os"
 
-	"golang.zx2c4.com/wireguard/conn"
+	"github.com/tailscale/wireguard-go/conn"
 )
 
 type ChannelBind struct {

--- a/device/bind_test.go
+++ b/device/bind_test.go
@@ -8,7 +8,7 @@ package device
 import (
 	"errors"
 
-	"golang.zx2c4.com/wireguard/conn"
+	"github.com/tailscale/wireguard-go/conn"
 )
 
 type DummyDatagram struct {

--- a/device/device.go
+++ b/device/device.go
@@ -11,10 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/ratelimiter"
-	"golang.zx2c4.com/wireguard/rwcancel"
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/ratelimiter"
+	"github.com/tailscale/wireguard-go/rwcancel"
+	"github.com/tailscale/wireguard-go/tun"
 )
 
 type Device struct {

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/conn/bindtest"
-	"golang.zx2c4.com/wireguard/tun"
-	"golang.zx2c4.com/wireguard/tun/tuntest"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/conn/bindtest"
+	"github.com/tailscale/wireguard-go/tun"
+	"github.com/tailscale/wireguard-go/tun/tuntest"
 )
 
 // uapiCfg returns a string that contains cfg formatted use with IpcSet.

--- a/device/keypair.go
+++ b/device/keypair.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.zx2c4.com/wireguard/replay"
+	"github.com/tailscale/wireguard-go/replay"
 )
 
 /* Due to limitations in Go and /x/crypto there is currently

--- a/device/noise-protocol.go
+++ b/device/noise-protocol.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/poly1305"
 
-	"golang.zx2c4.com/wireguard/tai64n"
+	"github.com/tailscale/wireguard-go/tai64n"
 )
 
 type handshakeState int

--- a/device/noise_test.go
+++ b/device/noise_test.go
@@ -10,8 +10,8 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/tun/tuntest"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/tun/tuntest"
 )
 
 func TestCurveWrappers(t *testing.T) {

--- a/device/peer.go
+++ b/device/peer.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
+	"github.com/tailscale/wireguard-go/conn"
 )
 
 type Peer struct {

--- a/device/queueconstants_android.go
+++ b/device/queueconstants_android.go
@@ -5,7 +5,7 @@
 
 package device
 
-import "golang.zx2c4.com/wireguard/conn"
+import "github.com/tailscale/wireguard-go/conn"
 
 /* Reduce memory consumption for Android */
 

--- a/device/queueconstants_default.go
+++ b/device/queueconstants_default.go
@@ -7,7 +7,7 @@
 
 package device
 
-import "golang.zx2c4.com/wireguard/conn"
+import "github.com/tailscale/wireguard-go/conn"
 
 const (
 	QueueStagedSize            = conn.IdealBatchSize

--- a/device/receive.go
+++ b/device/receive.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tailscale/wireguard-go/conn"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"golang.zx2c4.com/wireguard/conn"
 )
 
 type QueueHandshakeElement struct {

--- a/device/send.go
+++ b/device/send.go
@@ -14,10 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"golang.zx2c4.com/wireguard/tun"
 )
 
 /* Outbound flow

--- a/device/sticky_default.go
+++ b/device/sticky_default.go
@@ -3,8 +3,8 @@
 package device
 
 import (
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/rwcancel"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/rwcancel"
 )
 
 func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, error) {

--- a/device/sticky_linux.go
+++ b/device/sticky_linux.go
@@ -20,8 +20,8 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/rwcancel"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/rwcancel"
 )
 
 func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, error) {

--- a/device/tun.go
+++ b/device/tun.go
@@ -8,7 +8,7 @@ package device
 import (
 	"fmt"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/tailscale/wireguard-go/tun"
 )
 
 const DefaultMTU = 1420

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.zx2c4.com/wireguard/ipc"
+	"github.com/tailscale/wireguard-go/ipc"
 )
 
 type IPCError struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module golang.zx2c4.com/wireguard
+module github.com/tailscale/wireguard-go
 
 go 1.20
 

--- a/ipc/namedpipe/namedpipe_test.go
+++ b/ipc/namedpipe/namedpipe_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tailscale/wireguard-go/ipc/namedpipe"
 	"golang.org/x/sys/windows"
-	"golang.zx2c4.com/wireguard/ipc/namedpipe"
 )
 
 func randomPipePath() string {

--- a/ipc/uapi_linux.go
+++ b/ipc/uapi_linux.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/tailscale/wireguard-go/rwcancel"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/rwcancel"
 )
 
 type UAPIListener struct {

--- a/ipc/uapi_windows.go
+++ b/ipc/uapi_windows.go
@@ -8,8 +8,8 @@ package ipc
 import (
 	"net"
 
+	"github.com/tailscale/wireguard-go/ipc/namedpipe"
 	"golang.org/x/sys/windows"
-	"golang.zx2c4.com/wireguard/ipc/namedpipe"
 )
 
 // TODO: replace these with actual standard windows error numbers from the win package

--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/device"
+	"github.com/tailscale/wireguard-go/ipc"
+	"github.com/tailscale/wireguard-go/tun"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/ipc"
-	"golang.zx2c4.com/wireguard/tun"
 )
 
 const (

--- a/main_windows.go
+++ b/main_windows.go
@@ -12,11 +12,11 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/ipc"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/device"
+	"github.com/tailscale/wireguard-go/ipc"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/tailscale/wireguard-go/tun"
 )
 
 const (

--- a/tun/netstack/examples/http_client.go
+++ b/tun/netstack/examples/http_client.go
@@ -13,9 +13,9 @@ import (
 	"net/http"
 	"net/netip"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/device"
+	"github.com/tailscale/wireguard-go/tun/netstack"
 )
 
 func main() {

--- a/tun/netstack/examples/http_server.go
+++ b/tun/netstack/examples/http_server.go
@@ -14,9 +14,9 @@ import (
 	"net/http"
 	"net/netip"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/device"
+	"github.com/tailscale/wireguard-go/tun/netstack"
 )
 
 func main() {

--- a/tun/netstack/examples/ping_client.go
+++ b/tun/netstack/examples/ping_client.go
@@ -17,9 +17,9 @@ import (
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/device"
+	"github.com/tailscale/wireguard-go/tun/netstack"
 )
 
 func main() {

--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/tailscale/wireguard-go/tun"
 
 	"golang.org/x/net/dns/dnsmessage"
 	"gvisor.dev/gvisor/pkg/bufferv2"

--- a/tun/tcp_offload_linux.go
+++ b/tun/tcp_offload_linux.go
@@ -12,8 +12,8 @@ import (
 	"io"
 	"unsafe"
 
+	"github.com/tailscale/wireguard-go/conn"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
 )
 
 const tcpFlagsOffset = 13

--- a/tun/tcp_offload_linux_test.go
+++ b/tun/tcp_offload_linux_test.go
@@ -9,8 +9,8 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/tailscale/wireguard-go/conn"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 )

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -17,9 +17,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/tailscale/wireguard-go/conn"
+	"github.com/tailscale/wireguard-go/rwcancel"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/rwcancel"
 )
 
 const (

--- a/tun/tuntest/tuntest.go
+++ b/tun/tuntest/tuntest.go
@@ -11,7 +11,7 @@ import (
 	"net/netip"
 	"os"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/tailscale/wireguard-go/tun"
 )
 
 func Ping(dst, src netip.Addr) []byte {


### PR DESCRIPTION
The result of:

```
grep --include \*.go --include \*.mod -rl golang.zx2c4.com/wireguard . | xargs sed -i '' 's/golang.zx2c4.com\/wireguard/github.com\/tailscale\/wireguard-go/g'

grep --include \*.go -rl github.com/tailscale/wireguard-go . | xargs gofmt -w
```

`tailscale/tailscale` is currently pointing at a different branch, with feature-specific naming: https://github.com/tailscale/wireguard-go/commit/4fa124729667

The intent here is to generalize the branch name. With the new branch we are also pulling in the latest upstream changes. A `tailscale/tailscale` PR will follow to point at this commit.