### PR TITLE
adjust build tags for GOOS=tamago

### DIFF
--- a/conn/controlfns_unix.go
+++ b/conn/controlfns_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux && !wasm && !plan9
+//go:build !windows && !linux && !wasm && !plan9 && !tamago
 
 /* SPDX-License-Identifier: MIT
  *

--- a/ipc/uapi_tamago.go
+++ b/ipc/uapi_tamago.go
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+//go:build tamago
+
+package ipc
+
+// Made up sentinel error codes for tamago platform.
+const (
+	IpcErrorIO        = 1
+	IpcErrorInvalid   = 2
+	IpcErrorPortInUse = 3
+	IpcErrorUnknown   = 4
+	IpcErrorProtocol  = 5
+)

--- a/rwcancel/rwcancel.go
+++ b/rwcancel/rwcancel.go
@@ -1,4 +1,4 @@
-//go:build !windows && !wasm && !plan9
+//go:build !windows && !wasm && !plan9 && !tamago
 
 /* SPDX-License-Identifier: MIT
  *

--- a/rwcancel/rwcancel_stub.go
+++ b/rwcancel/rwcancel_stub.go
@@ -1,4 +1,4 @@
-//go:build windows || wasm || plan9
+//go:build windows || wasm || plan9 || tamago
 
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
This PR adjust build tags to allow compilation under the [TamaGo framework](https://github.com/usbarmory/tamago).