### PR TITLE
tun: export optimized IP checksum funcs

### DIFF
--- a/tun/checksum.go
+++ b/tun/checksum.go
@@ -702,7 +702,9 @@ func pseudoHeaderChecksum32(protocol uint8, srcAddr, dstAddr []byte, totalLen ui
 	return foldedSum
 }
 
-func pseudoHeaderChecksum(protocol uint8, srcAddr, dstAddr []byte, totalLen uint16) uint16 {
+// PseudoHeaderChecksum computes an IP pseudo-header checksum. srcAddr and
+// dstAddr must be 4 or 16 bytes in length.
+func PseudoHeaderChecksum(protocol uint8, srcAddr, dstAddr []byte, totalLen uint16) uint16 {
 	if strconv.IntSize < 64 {
 		return pseudoHeaderChecksum32(protocol, srcAddr, dstAddr, totalLen)
 	}

--- a/tun/checksum_amd64.go
+++ b/tun/checksum_amd64.go
@@ -2,11 +2,14 @@ package tun
 
 import "golang.org/x/sys/cpu"
 
-// checksum computes an IP checksum starting with the provided initial value.
-// The length of data should be at least 128 bytes for best performance. Smaller
-// buffers will still compute a correct result. For best performance with
-// smaller buffers, use shortChecksum().
 var checksum = checksumAMD64
+
+// Checksum computes an IP checksum starting with the provided initial value.
+// The length of data should be at least 128 bytes for best performance. Smaller
+// buffers will still compute a correct result.
+func Checksum(data []byte, initial uint16) uint16 {
+	return checksum(data, initial)
+}
 
 func init() {
 	if cpu.X86.HasAVX && cpu.X86.HasAVX2 && cpu.X86.HasBMI2 {

--- a/tun/checksum_generic.go
+++ b/tun/checksum_generic.go
@@ -7,7 +7,7 @@ package tun
 
 import "strconv"
 
-func checksum(data []byte, initial uint16) uint16 {
+func Checksum(data []byte, initial uint16) uint16 {
 	if strconv.IntSize < 64 {
 		return checksumGeneric32(data, initial)
 	}

--- a/tun/offload.go
+++ b/tun/offload.go
@@ -102,7 +102,7 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 			// the checksum we compute. This is typically the pseudo-header sum.
 			initial := binary.BigEndian.Uint16(in[cSumAt:])
 			in[cSumAt], in[cSumAt+1] = 0, 0
-			binary.BigEndian.PutUint16(in[cSumAt:], ^checksum(in[options.CsumStart:], initial))
+			binary.BigEndian.PutUint16(in[cSumAt:], ^Checksum(in[options.CsumStart:], initial))
 		}
 		sizes[0] = copy(outBufs[0][outOffset:], in)
 		return 1, nil
@@ -179,7 +179,7 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 			}
 			out[10], out[11] = 0, 0 // clear ipv4 header checksum
 			binary.BigEndian.PutUint16(out[2:], uint16(totalLen))
-			ipv4CSum := ^checksum(out[:iphLen], 0)
+			ipv4CSum := ^Checksum(out[:iphLen], 0)
 			binary.BigEndian.PutUint16(out[10:], ipv4CSum)
 		} else {
 			// For IPv6 we are responsible for updating the payload length field.
@@ -210,8 +210,8 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 		out[transportCsumAt], out[transportCsumAt+1] = 0, 0 // clear tcp/udp checksum
 		transportHeaderLen := int(options.HdrLen - options.CsumStart)
 		lenForPseudo := uint16(transportHeaderLen + segmentDataLen)
-		transportCSum := pseudoHeaderChecksum(protocol, in[srcAddrOffset:srcAddrOffset+addrLen], in[srcAddrOffset+addrLen:srcAddrOffset+addrLen*2], lenForPseudo)
-		transportCSum = ^checksum(out[options.CsumStart:totalLen], transportCSum)
+		transportCSum := PseudoHeaderChecksum(protocol, in[srcAddrOffset:srcAddrOffset+addrLen], in[srcAddrOffset+addrLen:srcAddrOffset+addrLen*2], lenForPseudo)
+		transportCSum = ^Checksum(out[options.CsumStart:totalLen], transportCSum)
 		binary.BigEndian.PutUint16(out[options.CsumStart+options.CsumOffset:], transportCSum)
 
 		nextSegmentDataAt += int(options.GSOSize)


### PR DESCRIPTION
External implementers of tun.Device may support GRO, requiring checksum offload.