### PR TITLE
ipc: build on solaris/illumos

### DIFF
--- a/ipc/uapi_fake.go
+++ b/ipc/uapi_fake.go
@@ -1,4 +1,4 @@
-//go:build wasm || plan9 || aix
+//go:build wasm || plan9 || aix || solaris || illumos
 
 /* SPDX-License-Identifier: MIT
  *


### PR DESCRIPTION
I haven't had time to work on further cleanup of the tun support for sunos for wireguard-go to get it into upstream wireguard. It does seem reasonable to at least get the sunos builds up to par with AIX in mainline tailscale though.
This is a necessary step for that.