### PR TITLE
conn,device: support conn.ReceiveFunc nonzero packet offset

### DIFF
--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -231,7 +231,7 @@ func (s *StdNetBind) receiveIP(
 	conn *net.UDPConn,
 	rxOffload bool,
 	bufs [][]byte,
-	sizes []int,
+	sizes [][2]int,
 	eps []Endpoint,
 ) (n int, err error) {
 	msgs := s.getMessages()
@@ -268,8 +268,8 @@ func (s *StdNetBind) receiveIP(
 	}
 	for i := 0; i < numMsgs; i++ {
 		msg := &(*msgs)[i]
-		sizes[i] = msg.N
-		if sizes[i] == 0 {
+		sizes[i][0], sizes[i][1] = 0, msg.N
+		if sizes[i][1] == 0 {
 			continue
 		}
 		addrPort := msg.Addr.(*net.UDPAddr).AddrPort()
@@ -281,13 +281,13 @@ func (s *StdNetBind) receiveIP(
 }
 
 func (s *StdNetBind) makeReceiveIPv4(pc *ipv4.PacketConn, conn *net.UDPConn, rxOffload bool) ReceiveFunc {
-	return func(bufs [][]byte, sizes []int, eps []Endpoint) (n int, err error) {
+	return func(bufs [][]byte, sizes [][2]int, eps []Endpoint) (n int, err error) {
 		return s.receiveIP(pc, conn, rxOffload, bufs, sizes, eps)
 	}
 }
 
 func (s *StdNetBind) makeReceiveIPv6(pc *ipv6.PacketConn, conn *net.UDPConn, rxOffload bool) ReceiveFunc {
-	return func(bufs [][]byte, sizes []int, eps []Endpoint) (n int, err error) {
+	return func(bufs [][]byte, sizes [][2]int, eps []Endpoint) (n int, err error) {
 		return s.receiveIP(pc, conn, rxOffload, bufs, sizes, eps)
 	}
 }

--- a/conn/bind_std_test.go
+++ b/conn/bind_std_test.go
@@ -17,7 +17,7 @@ func TestStdNetBindReceiveFuncAfterClose(t *testing.T) {
 	bind.Close()
 	bufs := make([][]byte, 1)
 	bufs[0] = make([]byte, 1)
-	sizes := make([]int, 1)
+	sizes := make([][2]int, 1)
 	eps := make([]Endpoint, 1)
 	for _, fn := range fns {
 		// The ReceiveFuncs must not access conn-related fields on StdNetBind

--- a/conn/bind_windows.go
+++ b/conn/bind_windows.go
@@ -416,20 +416,20 @@ retry:
 	return n, &ep, nil
 }
 
-func (bind *WinRingBind) receiveIPv4(bufs [][]byte, sizes []int, eps []Endpoint) (int, error) {
+func (bind *WinRingBind) receiveIPv4(bufs [][]byte, sizes [][2]int, eps []Endpoint) (int, error) {
 	bind.mu.RLock()
 	defer bind.mu.RUnlock()
 	n, ep, err := bind.v4.Receive(bufs[0], &bind.isOpen)
-	sizes[0] = n
+	sizes[0][0], sizes[0][1] = 0, n
 	eps[0] = ep
 	return 1, err
 }
 
-func (bind *WinRingBind) receiveIPv6(bufs [][]byte, sizes []int, eps []Endpoint) (int, error) {
+func (bind *WinRingBind) receiveIPv6(bufs [][]byte, sizes [][2]int, eps []Endpoint) (int, error) {
 	bind.mu.RLock()
 	defer bind.mu.RUnlock()
 	n, ep, err := bind.v6.Receive(bufs[0], &bind.isOpen)
-	sizes[0] = n
+	sizes[0][0], sizes[0][1] = 0, n
 	eps[0] = ep
 	return 1, err
 }

--- a/conn/bindtest/bindtest.go
+++ b/conn/bindtest/bindtest.go
@@ -94,13 +94,13 @@ func (c *ChannelBind) BatchSize() int { return 1 }
 func (c *ChannelBind) SetMark(mark uint32) error { return nil }
 
 func (c *ChannelBind) makeReceiveFunc(ch chan []byte) conn.ReceiveFunc {
-	return func(bufs [][]byte, sizes []int, eps []conn.Endpoint) (n int, err error) {
+	return func(bufs [][]byte, sizes [][2]int, eps []conn.Endpoint) (n int, err error) {
 		select {
 		case <-c.closeSignal:
 			return 0, net.ErrClosed
 		case rx := <-ch:
 			copied := copy(bufs[0], rx)
-			sizes[0] = copied
+			sizes[0][0], sizes[0][1] = 0, copied
 			eps[0] = c.target6
 			return 1, nil
 		}

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -21,11 +21,13 @@ const (
 
 // A ReceiveFunc receives at least one packet from the network and writes them
 // into packets. On a successful read it returns the number of elements of
-// sizes, packets, and endpoints that should be evaluated. Some elements of
-// sizes may be zero, and callers should ignore them. Callers must pass a sizes
-// and eps slice with a length greater than or equal to the length of packets.
-// These lengths must not exceed the length of the associated Bind.BatchSize().
-type ReceiveFunc func(packets [][]byte, sizes []int, eps []Endpoint) (n int, err error)
+// sizes, packets, and endpoints that should be evaluated. A sizes element
+// includes both the starting and ending offset for an element of packets. Some
+// elements of sizes may be zero, and callers should ignore them. Callers must
+// pass a sizes and eps slice with a length greater than or equal to the length
+// of packets. These lengths must not exceed the length of the associated
+// Bind.BatchSize().
+type ReceiveFunc func(packets [][]byte, sizes [][2]int, eps []Endpoint) (n int, err error)
 
 // A Bind listens on a port for both IPv6 and IPv4 UDP traffic.
 //

--- a/conn/conn_test.go
+++ b/conn/conn_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPrettyName(t *testing.T) {
 	var (
-		recvFunc ReceiveFunc = func(bufs [][]byte, sizes []int, eps []Endpoint) (n int, err error) { return }
+		recvFunc ReceiveFunc = func(bufs [][]byte, sizes [][2]int, eps []Endpoint) (n int, err error) { return }
 	)
 
 	const want = "TestPrettyName"

--- a/device/receive.go
+++ b/device/receive.go
@@ -86,7 +86,7 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 		bufsArrs    = make([]*[MaxMessageSize]byte, maxBatchSize)
 		bufs        = make([][]byte, maxBatchSize)
 		err         error
-		sizes       = make([]int, maxBatchSize)
+		sizes       = make([][2]int, maxBatchSize)
 		count       int
 		endpoints   = make([]conn.Endpoint, maxBatchSize)
 		deathSpiral int
@@ -127,13 +127,16 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 
 		// handle each packet in the batch
 		for i, size := range sizes[:count] {
-			if size < MinMessageSize {
+			if size[1] < size[0] {
+				continue
+			}
+			if size[1]-size[0] < MinMessageSize {
 				continue
 			}
 
 			// check size of packet
 
-			packet := bufsArrs[i][:size]
+			packet := bufsArrs[i][size[0]:size[1]]
 			msgType := binary.LittleEndian.Uint32(packet[:4])
 
 			switch msgType {


### PR DESCRIPTION
This enables a conn.Bind to leverage wireguard-go packet memory for reading packets containing layers that wireguard-go should ignore, e.g. a VXLAN or Geneve header preceeding WireGuard.