### PR TITLE
conn,device: always perform PeerAwareEndpoint check

### DIFF
--- a/conn/conn.go
+++ b/conn/conn.go
@@ -87,17 +87,21 @@ type Endpoint interface {
 }
 
 // PeerAwareEndpoint is an optional Endpoint specialization for
-// integrations that want to know about the outcome of cryptorouting
+// integrations that want to know about the outcome of Cryptokey Routing
 // identification.
 //
 // If they receive a packet from a source they had not pre-identified,
 // to learn the identification WireGuard can derive from the session
 // or handshake.
 //
-// If GetPeerEndpoint returns nil, WireGuard will be unable to respond
-// to the peer until a new endpoint is written by a later packet.
+// wireguard-go never installs a [PeerAwareEndpoint] as the [Endpoint] for a
+// [Peer].
 type PeerAwareEndpoint interface {
-	GetPeerEndpoint(peerPublicKey [32]byte) Endpoint
+	// FromPeer is called at least once per successfully Cryptokey Routing ID'd
+	// [ReceiveFunc] packets batch for a given node key. wireguard-go will
+	// always call it for the latest/tail packet in the batch, only ever
+	// suppressing calls for older packets.
+	FromPeer(peerPublicKey [32]byte)
 }
 
 var (

--- a/device/peer.go
+++ b/device/peer.go
@@ -282,13 +282,14 @@ func (peer *Peer) Stop() {
 func (peer *Peer) SetEndpointFromPacket(endpoint conn.Endpoint) {
 	peer.endpoint.Lock()
 	defer peer.endpoint.Unlock()
+	if ep, ok := endpoint.(conn.PeerAwareEndpoint); ok {
+		ep.FromPeer(peer.handshake.remoteStatic)
+		return
+	}
 	if peer.endpoint.disableRoaming {
 		return
 	}
 	peer.endpoint.clearSrcOnTx = false
-	if ep, ok := endpoint.(conn.PeerAwareEndpoint); ok {
-		endpoint = ep.GetPeerEndpoint(peer.handshake.remoteStatic)
-	}
 	peer.endpoint.val = endpoint
 }
 


### PR DESCRIPTION
It was previously suppressed if roaming was disabled for the peer. Tailscale always disables roaming as we explicitly configure conn.Endpoint's per peer.

This also commit modifies PeerAwareEndpoint usage such that wireguard-go never uses/sets it as a Peer Endpoint value. In theory we (Tailscale) always disable roaming, so we should always return early from SetEndpointFromPacket(), but this acts as an extra footgun guard and improves clarity around intended usage.

Updates tailscale/corp#27502
Updates tailscale/corp#30042