### PR TITLE
device: fix slow test and go vet

### DIFF
--- a/device/pools_test.go
+++ b/device/pools_test.go
@@ -17,7 +17,10 @@ import (
 func TestWaitPool(t *testing.T) {
 	var wg sync.WaitGroup
 	var trials atomic.Int32
-	startTrials := int32(100000)
+	n := runtime.NumCPU()
+	// The original test of 100,000 trials resulted in very long times on small hosts.
+	// Scaling it down to 100*n^2 results a 1.5s run on a 4-core VM.
+	startTrials := int32(min(100*n*n, 100000))
 	if raceEnabled {
 		// This test can be very slow with -race.
 		startTrials /= 10
@@ -63,7 +66,7 @@ func TestWaitPool(t *testing.T) {
 	}
 	wg.Wait()
 	if max.Load() != p.max {
-		t.Errorf("Actual maximum count (%d) != ideal maximum count (%d)", max, p.max)
+		t.Errorf("Actual maximum count (%d) != ideal maximum count (%d)", max.Load(), p.max)
 	}
 }
 


### PR DESCRIPTION
TestWaitPool now scales better to small hosts,
and no longer triggers `go vet`.


Change-Id: I97a2d22561468de14b17e09d557f212b6a6a6964