### PR TITLE
device: extract pool into standalone package

### DIFF
--- a/device/channels.go
+++ b/device/channels.go
@@ -90,9 +90,9 @@ func newAutodrainingInboundQueue(device *Device) *autodrainingInboundQueue {
 }
 
 func (device *Device) needsInboundQueueFinalizer() bool {
-	return device.pool.messageBuffers.hasAccounting() ||
-		device.pool.inboundElements.hasAccounting() ||
-		device.pool.inboundElementsContainer.hasAccounting()
+	return device.pool.messageBuffers.HasAccounting() ||
+		device.pool.inboundElements.HasAccounting() ||
+		device.pool.inboundElementsContainer.HasAccounting()
 }
 
 func (device *Device) flushInboundQueue(q *autodrainingInboundQueue) {
@@ -131,9 +131,9 @@ func newAutodrainingOutboundQueue(device *Device) *autodrainingOutboundQueue {
 }
 
 func (device *Device) needsOutboundQueueFinalizer() bool {
-	return device.pool.messageBuffers.hasAccounting() ||
-		device.pool.outboundElements.hasAccounting() ||
-		device.pool.outboundElementsContainer.hasAccounting()
+	return device.pool.messageBuffers.HasAccounting() ||
+		device.pool.outboundElements.HasAccounting() ||
+		device.pool.outboundElementsContainer.HasAccounting()
 }
 
 func (device *Device) flushOutboundQueue(q *autodrainingOutboundQueue) {

--- a/device/channels_test.go
+++ b/device/channels_test.go
@@ -5,11 +5,15 @@
 
 package device
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/tailscale/wireguard-go/waitpool"
+)
 
 func TestAutodrainingQueueFinalizerNeedTracksPoolAccounting(t *testing.T) {
-	unbounded := func() *WaitPool { return NewWaitPool(0, func() any { return nil }) }
-	bounded := func() *WaitPool { return NewWaitPool(1, func() any { return nil }) }
+	unbounded := func() *waitpool.WaitPool { return waitpool.New(0, func() any { return nil }) }
+	bounded := func() *waitpool.WaitPool { return waitpool.New(1, func() any { return nil }) }
 
 	device := &Device{}
 	device.pool.messageBuffers = unbounded()

--- a/device/device.go
+++ b/device/device.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tailscale/wireguard-go/ratelimiter"
 	"github.com/tailscale/wireguard-go/rwcancel"
 	"github.com/tailscale/wireguard-go/tun"
+	"github.com/tailscale/wireguard-go/waitpool"
 )
 
 type Device struct {
@@ -75,11 +76,11 @@ type Device struct {
 	cookieChecker CookieChecker
 
 	pool struct {
-		inboundElementsContainer  *WaitPool
-		outboundElementsContainer *WaitPool
-		messageBuffers            *WaitPool
-		inboundElements           *WaitPool
-		outboundElements          *WaitPool
+		inboundElementsContainer  *waitpool.WaitPool
+		outboundElementsContainer *waitpool.WaitPool
+		messageBuffers            *waitpool.WaitPool
+		inboundElements           *waitpool.WaitPool
+		outboundElements          *waitpool.WaitPool
 	}
 
 	queue struct {

--- a/device/device.go
+++ b/device/device.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tailscale/wireguard-go/ratelimiter"
 	"github.com/tailscale/wireguard-go/rwcancel"
 	"github.com/tailscale/wireguard-go/tun"
+	"github.com/tailscale/wireguard-go/waitpool"
 )
 
 type Device struct {
@@ -71,11 +72,11 @@ type Device struct {
 	cookieChecker CookieChecker
 
 	pool struct {
-		inboundElementsContainer  *WaitPool
-		outboundElementsContainer *WaitPool
-		messageBuffers            *WaitPool
-		inboundElements           *WaitPool
-		outboundElements          *WaitPool
+		inboundElementsContainer  *waitpool.WaitPool
+		outboundElementsContainer *waitpool.WaitPool
+		messageBuffers            *waitpool.WaitPool
+		inboundElements           *waitpool.WaitPool
+		outboundElements          *waitpool.WaitPool
 	}
 
 	queue struct {

--- a/device/pools.go
+++ b/device/pools.go
@@ -6,66 +6,25 @@
 package device
 
 import (
-	"sync"
+	"github.com/tailscale/wireguard-go/waitpool"
 )
 
-type WaitPool struct {
-	pool  sync.Pool
-	cond  sync.Cond
-	lock  sync.Mutex
-	count uint32 // Get calls not yet Put back
-	max   uint32
-}
-
-func NewWaitPool(max uint32, new func() any) *WaitPool {
-	p := &WaitPool{pool: sync.Pool{New: new}, max: max}
-	p.cond = sync.Cond{L: &p.lock}
-	return p
-}
-
-func (p *WaitPool) hasAccounting() bool {
-	return p != nil && p.max != 0
-}
-
-func (p *WaitPool) Get() any {
-	if p.max != 0 {
-		p.lock.Lock()
-		for p.count >= p.max {
-			p.cond.Wait()
-		}
-		p.count++
-		p.lock.Unlock()
-	}
-	return p.pool.Get()
-}
-
-func (p *WaitPool) Put(x any) {
-	p.pool.Put(x)
-	if p.max == 0 {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	p.count--
-	p.cond.Signal()
-}
-
 func (device *Device) PopulatePools() {
-	device.pool.inboundElementsContainer = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.inboundElementsContainer = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		s := make([]*QueueInboundElement, 0, device.BatchSize())
 		return &QueueInboundElementsContainer{elems: s}
 	})
-	device.pool.outboundElementsContainer = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.outboundElementsContainer = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		s := make([]*QueueOutboundElement, 0, device.BatchSize())
 		return &QueueOutboundElementsContainer{elems: s}
 	})
-	device.pool.messageBuffers = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.messageBuffers = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		return new([MaxMessageSize]byte)
 	})
-	device.pool.inboundElements = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.inboundElements = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		return new(QueueInboundElement)
 	})
-	device.pool.outboundElements = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.outboundElements = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		return new(QueueOutboundElement)
 	})
 }

--- a/device/pools.go
+++ b/device/pools.go
@@ -7,61 +7,26 @@ package device
 
 import (
 	"sync"
+
+	"github.com/tailscale/wireguard-go/waitpool"
 )
 
-type WaitPool struct {
-	pool  sync.Pool
-	cond  sync.Cond
-	lock  sync.Mutex
-	count uint32 // Get calls not yet Put back
-	max   uint32
-}
-
-func NewWaitPool(max uint32, new func() any) *WaitPool {
-	p := &WaitPool{pool: sync.Pool{New: new}, max: max}
-	p.cond = sync.Cond{L: &p.lock}
-	return p
-}
-
-func (p *WaitPool) Get() any {
-	if p.max != 0 {
-		p.lock.Lock()
-		for p.count >= p.max {
-			p.cond.Wait()
-		}
-		p.count++
-		p.lock.Unlock()
-	}
-	return p.pool.Get()
-}
-
-func (p *WaitPool) Put(x any) {
-	p.pool.Put(x)
-	if p.max == 0 {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	p.count--
-	p.cond.Signal()
-}
-
 func (device *Device) PopulatePools() {
-	device.pool.inboundElementsContainer = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.inboundElementsContainer = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		s := make([]*QueueInboundElement, 0, device.BatchSize())
 		return &QueueInboundElementsContainer{elems: s}
 	})
-	device.pool.outboundElementsContainer = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.outboundElementsContainer = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		s := make([]*QueueOutboundElement, 0, device.BatchSize())
 		return &QueueOutboundElementsContainer{elems: s}
 	})
-	device.pool.messageBuffers = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.messageBuffers = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		return new([MaxMessageSize]byte)
 	})
-	device.pool.inboundElements = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.inboundElements = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		return new(QueueInboundElement)
 	})
-	device.pool.outboundElements = NewWaitPool(PreallocatedBuffersPerPool, func() any {
+	device.pool.outboundElements = waitpool.New(PreallocatedBuffersPerPool, func() any {
 		return new(QueueOutboundElement)
 	})
 }

--- a/device/queueconstants_ios.go
+++ b/device/queueconstants_ios.go
@@ -11,11 +11,11 @@ package device
 // These are vars instead of consts, because heavier network extensions might want to reduce
 // them further.
 var (
-	QueueStagedSize                   = 128
-	QueueOutboundSize                 = 1024
-	QueueInboundSize                  = 1024
-	QueueHandshakeSize                = 1024
-	PreallocatedBuffersPerPool uint32 = 1024
+	QueueStagedSize            = 128
+	QueueOutboundSize          = 1024
+	QueueInboundSize           = 1024
+	QueueHandshakeSize         = 1024
+	PreallocatedBuffersPerPool = 1024
 )
 
 const MaxSegmentSize = 1700

--- a/waitpool/race_disabled_test.go
+++ b/waitpool/race_disabled_test.go
@@ -5,6 +5,6 @@
  * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
  */
 
-package device
+package waitpool
 
 const raceEnabled = false

--- a/waitpool/race_enabled_test.go
+++ b/waitpool/race_enabled_test.go
@@ -5,6 +5,6 @@
  * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
  */
 
-package device
+package waitpool
 
 const raceEnabled = true

--- a/waitpool/waitpool.go
+++ b/waitpool/waitpool.go
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+// Package waitpool provides a sync.Pool wrapper that caps the number of
+// concurrently checked-out elements, blocking Get when the cap is reached.
+package waitpool
+
+import (
+	"sync"
+)
+
+// WaitPool is a sync.Pool with an optional concurrency cap. When max > 0,
+// Get blocks once max elements are checked out until a corresponding Put
+// returns one. When max == 0 there is no cap and Get never blocks.
+type WaitPool struct {
+	pool  sync.Pool
+	cond  sync.Cond
+	lock  sync.Mutex
+	count int // Get calls not yet Put back
+	max   int
+}
+
+// New returns a WaitPool with the given concurrency cap and constructor.
+// A max of 0 (or negative) disables the cap.
+func New(max int, newFn func() any) *WaitPool {
+	if max < 0 {
+		max = 0
+	}
+	p := &WaitPool{pool: sync.Pool{New: newFn}, max: max}
+	p.cond = sync.Cond{L: &p.lock}
+	return p
+}
+
+// HasAccounting reports whether the pool enforces a concurrency cap.
+func (p *WaitPool) HasAccounting() bool {
+	return p != nil && p.max != 0
+}
+
+// Get returns an element from the pool, blocking if the concurrency cap is reached.
+func (p *WaitPool) Get() any {
+	if p.max != 0 {
+		p.lock.Lock()
+		for p.count >= p.max {
+			p.cond.Wait()
+		}
+		p.count++
+		p.lock.Unlock()
+	}
+	return p.pool.Get()
+}
+
+// Put returns an element to the pool and unblocks one waiting Get if any.
+func (p *WaitPool) Put(x any) {
+	p.pool.Put(x)
+	if p.max == 0 {
+		return
+	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.count--
+	p.cond.Signal()
+}

--- a/waitpool/waitpool.go
+++ b/waitpool/waitpool.go
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+// Package waitpool provides a sync.Pool wrapper that caps the number of
+// concurrently checked-out elements, blocking Get when the cap is reached.
+package waitpool
+
+import (
+	"sync"
+)
+
+// WaitPool is a sync.Pool with an optional concurrency cap. When max > 0,
+// Get blocks once max elements are checked out until a corresponding Put
+// returns one. When max == 0 there is no cap and Get never blocks.
+type WaitPool struct {
+	pool  sync.Pool
+	cond  sync.Cond
+	lock  sync.Mutex
+	count int // Get calls not yet Put back
+	max   int
+}
+
+// New returns a WaitPool with the given concurrency cap and constructor.
+// A max of 0 (or negative) disables the cap.
+func New(max int, newFn func() any) *WaitPool {
+	if max < 0 {
+		max = 0
+	}
+	p := &WaitPool{pool: sync.Pool{New: newFn}, max: max}
+	p.cond = sync.Cond{L: &p.lock}
+	return p
+}
+
+// Get returns an element from the pool, blocking if the concurrency cap is reached.
+func (p *WaitPool) Get() any {
+	if p.max != 0 {
+		p.lock.Lock()
+		for p.count >= p.max {
+			p.cond.Wait()
+		}
+		p.count++
+		p.lock.Unlock()
+	}
+	return p.pool.Get()
+}
+
+// Put returns an element to the pool and unblocks one waiting Get if any.
+func (p *WaitPool) Put(x any) {
+	p.pool.Put(x)
+	if p.max == 0 {
+		return
+	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.count--
+	p.cond.Signal()
+}

--- a/waitpool/waitpool_test.go
+++ b/waitpool/waitpool_test.go
@@ -3,7 +3,7 @@
  * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
  */
 
-package device
+package waitpool
 
 import (
 	"math/rand"
@@ -30,9 +30,9 @@ func TestWaitPool(t *testing.T) {
 	if workers-4 <= 0 {
 		t.Skip("Not enough cores")
 	}
-	p := NewWaitPool(uint32(workers-4), func() any { return make([]byte, 16) })
+	p := New(workers-4, func() any { return make([]byte, 16) })
 	wg.Add(workers)
-	var max atomic.Uint32
+	var max atomic.Int64
 	updateMax := func() {
 		p.lock.Lock()
 		count := p.count
@@ -42,10 +42,10 @@ func TestWaitPool(t *testing.T) {
 		}
 		for {
 			old := max.Load()
-			if count <= old {
+			if int64(count) <= old {
 				break
 			}
-			if max.CompareAndSwap(old, count) {
+			if max.CompareAndSwap(old, int64(count)) {
 				break
 			}
 		}
@@ -65,7 +65,7 @@ func TestWaitPool(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	if max.Load() != p.max {
+	if max.Load() != int64(p.max) {
 		t.Errorf("Actual maximum count (%d) != ideal maximum count (%d)", max.Load(), p.max)
 	}
 }
@@ -78,7 +78,7 @@ func BenchmarkWaitPool(b *testing.B) {
 	if workers-4 <= 0 {
 		b.Skip("Not enough cores")
 	}
-	p := NewWaitPool(uint32(workers-4), func() any { return make([]byte, 16) })
+	p := New(workers-4, func() any { return make([]byte, 16) })
 	wg.Add(workers)
 	b.ResetTimer()
 	for i := 0; i < workers; i++ {
@@ -102,7 +102,7 @@ func BenchmarkWaitPoolEmpty(b *testing.B) {
 	if workers-4 <= 0 {
 		b.Skip("Not enough cores")
 	}
-	p := NewWaitPool(0, func() any { return make([]byte, 16) })
+	p := New(0, func() any { return make([]byte, 16) })
 	wg.Add(workers)
 	b.ResetTimer()
 	for i := 0; i < workers; i++ {


### PR DESCRIPTION
e.g. to access it without importing `device`.