### PR TITLE
device: fix CI failing when AF_ALG is unavailable

### DIFF
--- a/device/aead_compat_linux_test.go
+++ b/device/aead_compat_linux_test.go
@@ -12,5 +12,9 @@ import (
 // On Linux, run the shared AEAD compatibility test suite against the
 // AF_ALG-backed implementation in addition to the Go reference.
 func init() {
+	if afalg.SelfTest() != nil {
+		// Same as [chacha20poly1305New], skip when the kernel module is unavailable.
+		return
+	}
 	aeadCtors = append(aeadCtors, aeadCtorEntry{"af_alg", afalg.New})
 }


### PR DESCRIPTION
TestAEAD_Concurrent/af_alg fails on our CI hosts because Ubuntu is disabling algif_aead module by default.
This replicates the runtime mechanism to skip AF_ALG implementation when the module is unavailable.

Updates tailscale/tailscale#7053


Change-Id: I3edd2bff747a168957d666930adff8eb6a6a6964