### PR TITLE
tun: validate GSO checksum offset fits within HdrLen

### DIFF
--- a/tun/offload.go
+++ b/tun/offload.go
@@ -111,6 +111,9 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 	if options.HdrLen < options.CsumStart {
 		return 0, fmt.Errorf("GSO HdrLen (%d) < GSO CsumStart (%d)", options.HdrLen, options.CsumStart)
 	}
+	if int(options.CsumStart)+int(options.CsumOffset)+2 > int(options.HdrLen) {
+		return 0, fmt.Errorf("GSO checksum field end (%d) exceeds HdrLen (%d)", int(options.CsumStart)+int(options.CsumOffset)+2, options.HdrLen)
+	}
 
 	ipVersion := in[0] >> 4
 	switch ipVersion {


### PR DESCRIPTION
GSOSplit only bounded the checksum offset against the input packet length, not against HdrLen. With CsumStart+CsumOffset+2 > HdrLen, the per-segment output buffer (sized to HdrLen+segmentDataLen) is too short and writing the transport checksum panics with an index out of range.
Reject the options up front instead. 