### PR TITLE
device, tsasm/mips: add ChaCha20-Poly1305 assembly for GOARCH=mips, mipsle, and mips64

### DIFF
--- a/device/aead_mips32.go
+++ b/device/aead_mips32.go
@@ -1,0 +1,34 @@
+//go:build mips || mipsle
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"crypto/cipher"
+	"os"
+
+	"golang.org/x/crypto/chacha20poly1305"
+
+	asmAEAD "github.com/tailscale/wireguard-go/tsasm/mips32/chacha20poly1305"
+)
+
+// chacha20poly1305New returns a ChaCha20-Poly1305 AEAD. On
+// big-endian GOARCH=mips it uses the hand-written scalar mips32r2
+// kernels in tsasm/mips32/, both for ChaCha20 and Poly1305 -- the
+// 5x26 layout maps cleanly onto the 32-bit registers and the
+// pure-Go path emulates uint64 multiplies, so both halves win in
+// asm here.
+//
+// As an escape hatch for hardware regressions or asm bugs, setting
+// the environment variable TS_WG_ASM=0 forces the pure-Go x/crypto
+// implementation instead.
+func chacha20poly1305New(key []byte) (cipher.AEAD, error) {
+	if os.Getenv("TS_WG_ASM") == "0" {
+		return chacha20poly1305.New(key)
+	}
+	return asmAEAD.New(key)
+}

--- a/device/aead_mips64.go
+++ b/device/aead_mips64.go
@@ -1,0 +1,34 @@
+//go:build mips64
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"crypto/cipher"
+	"os"
+
+	"golang.org/x/crypto/chacha20poly1305"
+
+	asmAEAD "github.com/tailscale/wireguard-go/tsasm/mips64/chacha20poly1305"
+)
+
+// chacha20poly1305New returns a ChaCha20-Poly1305 AEAD. On
+// GOARCH=mips64 / mips64le it uses the hand-written scalar
+// mips64r2 ChaCha20 from tsasm/mips64/, paired with the pure-Go
+// Poly1305 from golang.org/x/crypto. ChaCha20 is the dominant cost
+// (~70% of the AEAD on Octeon II) so this is the right slice to
+// optimize first.
+//
+// As an escape hatch for hardware regressions or asm bugs, setting
+// the environment variable TS_WG_ASM=0 forces the pure-Go x/crypto
+// implementation instead.
+func chacha20poly1305New(key []byte) (cipher.AEAD, error) {
+	if os.Getenv("TS_WG_ASM") == "0" {
+		return chacha20poly1305.New(key)
+	}
+	return asmAEAD.New(key)
+}

--- a/device/aead_other.go
+++ b/device/aead_other.go
@@ -1,4 +1,4 @@
-//go:build !arm
+//go:build !arm && !mips64 && !mips && !mipsle
 
 /* SPDX-License-Identifier: MIT
  *

--- a/tsasm/mips32/chacha20/chacha20_mips32.go
+++ b/tsasm/mips32/chacha20/chacha20_mips32.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips || mipsle
+
+// Package chacha20 implements the ChaCha20 stream cipher with a
+// scalar mips32r2 inner loop. It only builds on GOARCH=mips and
+// GOARCH=mipsle; mips64 / mips64le should use tsasm/mips64/chacha20,
+// other architectures should use golang.org/x/crypto/chacha20.
+package chacha20
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+const (
+	KeySize   = 32
+	NonceSize = 12
+	BlockSize = 64
+)
+
+const (
+	sigma0 uint32 = 0x61707865
+	sigma1 uint32 = 0x3320646e
+	sigma2 uint32 = 0x79622d32
+	sigma3 uint32 = 0x6b206574
+)
+
+//go:noescape
+func chacha20BlocksASM(out, in unsafe.Pointer, state *[16]uint32, blocks uintptr)
+
+// XORKeyStream XORs a ChaCha20 keystream into in, writing to out, using
+// the given 32-byte key, 12-byte IETF nonce, and starting 32-bit block
+// counter. out and in must have the same length and may overlap exactly
+// or not at all. It returns the next block counter
+// (counter + ceil(len/64)).
+//
+// Both `out` and `in` should be 4-byte aligned. Slices from make()
+// are; slices derived from string literals (which may live in
+// rodata) are not. The asm reads/writes 32-bit words; on stricter
+// MIPS environments (qemu-user, certain bare-metal kernels)
+// unaligned access raises SIGBUS. WireGuard's data path uses pooled
+// make()-allocated buffers and is therefore safe.
+func XORKeyStream(out, in []byte, key *[KeySize]byte, nonce *[NonceSize]byte, counter uint32) uint32 {
+	if len(out) < len(in) {
+		panic("chacha20: output buffer shorter than input")
+	}
+	if len(in) == 0 {
+		return counter
+	}
+
+	var state [16]uint32
+	state[0] = sigma0
+	state[1] = sigma1
+	state[2] = sigma2
+	state[3] = sigma3
+	for i := range 8 {
+		state[4+i] = binary.LittleEndian.Uint32(key[i*4:])
+	}
+	state[12] = counter
+	state[13] = binary.LittleEndian.Uint32(nonce[0:])
+	state[14] = binary.LittleEndian.Uint32(nonce[4:])
+	state[15] = binary.LittleEndian.Uint32(nonce[8:])
+
+	full := len(in) &^ 63
+	if full > 0 {
+		chacha20BlocksASM(
+			unsafe.Pointer(&out[0]),
+			unsafe.Pointer(&in[0]),
+			&state,
+			uintptr(full>>6),
+		)
+	}
+	if rem := len(in) - full; rem > 0 {
+		var inBuf, outBuf [64]byte
+		copy(inBuf[:], in[full:])
+		chacha20BlocksASM(
+			unsafe.Pointer(&outBuf[0]),
+			unsafe.Pointer(&inBuf[0]),
+			&state,
+			1,
+		)
+		copy(out[full:], outBuf[:rem])
+	}
+
+	return counter + uint32((len(in)+63)>>6)
+}

--- a/tsasm/mips32/chacha20/chacha20_mips_be.s
+++ b/tsasm/mips32/chacha20/chacha20_mips_be.s
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips
+
+#include "textflag.h"
+
+// chacha20BlocksASM(out, in unsafe.Pointer, state *[16]uint32, blocks uintptr)
+//
+// 32-bit MIPS r2 (Plan 9 syntax) port of the mips64 ChaCha20 inner
+// loop in tsasm/mips64/chacha20/chacha20_mips64.s.  The algorithm
+// is unchanged: 16 32-bit state words live in registers (R2..R17)
+// across the 20 rounds, rotates use MIPS r2 ROTR, and the LE byte
+// swap on input/output uses WSBH+ROTR16. The differences from the
+// mips64 port are mechanical:
+//   * 4-byte args, frame layout uses MOVW for pointer loads.
+//   * 4-byte pointer increments via ADDU instead of ADDV.
+//   * Block counter decrement via SUBU instead of SUBVU.
+//
+// Register usage is identical to the mips64 port; see that file for
+// the rationale.
+TEXT ·chacha20BlocksASM(SB), NOSPLIT|NOFRAME, $0-16
+	MOVW	out+0(FP), R18
+	MOVW	in+4(FP), R19
+	MOVW	state+8(FP), R20
+	MOVW	blocks+12(FP), R21
+
+	BEQ	R21, done
+
+block_loop:
+	MOVW	0(R20), R2
+	MOVW	4(R20), R3
+	MOVW	8(R20), R4
+	MOVW	12(R20), R5
+	MOVW	16(R20), R6
+	MOVW	20(R20), R7
+	MOVW	24(R20), R8
+	MOVW	28(R20), R9
+	MOVW	32(R20), R10
+	MOVW	36(R20), R11
+	MOVW	40(R20), R12
+	MOVW	44(R20), R13
+	MOVW	48(R20), R14
+	MOVW	52(R20), R15
+	MOVW	56(R20), R16
+	MOVW	60(R20), R17
+
+	MOVW	$10, R24
+
+round_loop:
+	// Column round.
+	ADDU	R6, R2, R2
+	XOR	R2, R14, R14
+	ROTR	$16, R14, R14
+	ADDU	R14, R10, R10
+	XOR	R10, R6, R6
+	ROTR	$20, R6, R6
+	ADDU	R6, R2, R2
+	XOR	R2, R14, R14
+	ROTR	$24, R14, R14
+	ADDU	R14, R10, R10
+	XOR	R10, R6, R6
+	ROTR	$25, R6, R6
+
+	ADDU	R7, R3, R3
+	XOR	R3, R15, R15
+	ROTR	$16, R15, R15
+	ADDU	R15, R11, R11
+	XOR	R11, R7, R7
+	ROTR	$20, R7, R7
+	ADDU	R7, R3, R3
+	XOR	R3, R15, R15
+	ROTR	$24, R15, R15
+	ADDU	R15, R11, R11
+	XOR	R11, R7, R7
+	ROTR	$25, R7, R7
+
+	ADDU	R8, R4, R4
+	XOR	R4, R16, R16
+	ROTR	$16, R16, R16
+	ADDU	R16, R12, R12
+	XOR	R12, R8, R8
+	ROTR	$20, R8, R8
+	ADDU	R8, R4, R4
+	XOR	R4, R16, R16
+	ROTR	$24, R16, R16
+	ADDU	R16, R12, R12
+	XOR	R12, R8, R8
+	ROTR	$25, R8, R8
+
+	ADDU	R9, R5, R5
+	XOR	R5, R17, R17
+	ROTR	$16, R17, R17
+	ADDU	R17, R13, R13
+	XOR	R13, R9, R9
+	ROTR	$20, R9, R9
+	ADDU	R9, R5, R5
+	XOR	R5, R17, R17
+	ROTR	$24, R17, R17
+	ADDU	R17, R13, R13
+	XOR	R13, R9, R9
+	ROTR	$25, R9, R9
+
+	// Diagonal round.
+	ADDU	R7, R2, R2
+	XOR	R2, R17, R17
+	ROTR	$16, R17, R17
+	ADDU	R17, R12, R12
+	XOR	R12, R7, R7
+	ROTR	$20, R7, R7
+	ADDU	R7, R2, R2
+	XOR	R2, R17, R17
+	ROTR	$24, R17, R17
+	ADDU	R17, R12, R12
+	XOR	R12, R7, R7
+	ROTR	$25, R7, R7
+
+	ADDU	R8, R3, R3
+	XOR	R3, R14, R14
+	ROTR	$16, R14, R14
+	ADDU	R14, R13, R13
+	XOR	R13, R8, R8
+	ROTR	$20, R8, R8
+	ADDU	R8, R3, R3
+	XOR	R3, R14, R14
+	ROTR	$24, R14, R14
+	ADDU	R14, R13, R13
+	XOR	R13, R8, R8
+	ROTR	$25, R8, R8
+
+	ADDU	R9, R4, R4
+	XOR	R4, R15, R15
+	ROTR	$16, R15, R15
+	ADDU	R15, R10, R10
+	XOR	R10, R9, R9
+	ROTR	$20, R9, R9
+	ADDU	R9, R4, R4
+	XOR	R4, R15, R15
+	ROTR	$24, R15, R15
+	ADDU	R15, R10, R10
+	XOR	R10, R9, R9
+	ROTR	$25, R9, R9
+
+	ADDU	R6, R5, R5
+	XOR	R5, R16, R16
+	ROTR	$16, R16, R16
+	ADDU	R16, R11, R11
+	XOR	R11, R6, R6
+	ROTR	$20, R6, R6
+	ADDU	R6, R5, R5
+	XOR	R5, R16, R16
+	ROTR	$24, R16, R16
+	ADDU	R16, R11, R11
+	XOR	R11, R6, R6
+	ROTR	$25, R6, R6
+
+	SUBU	$1, R24
+	BNE	R24, round_loop
+
+	// x[i] += state[i].
+	MOVW	0(R20), R22
+	ADDU	R22, R2, R2
+	MOVW	4(R20), R22
+	ADDU	R22, R3, R3
+	MOVW	8(R20), R22
+	ADDU	R22, R4, R4
+	MOVW	12(R20), R22
+	ADDU	R22, R5, R5
+	MOVW	16(R20), R22
+	ADDU	R22, R6, R6
+	MOVW	20(R20), R22
+	ADDU	R22, R7, R7
+	MOVW	24(R20), R22
+	ADDU	R22, R8, R8
+	MOVW	28(R20), R22
+	ADDU	R22, R9, R9
+	MOVW	32(R20), R22
+	ADDU	R22, R10, R10
+	MOVW	36(R20), R22
+	ADDU	R22, R11, R11
+	MOVW	40(R20), R22
+	ADDU	R22, R12, R12
+	MOVW	44(R20), R22
+	ADDU	R22, R13, R13
+	MOVW	48(R20), R22
+	ADDU	R22, R14, R14
+	MOVW	52(R20), R22
+	ADDU	R22, R15, R15
+	MOVW	56(R20), R22
+	ADDU	R22, R16, R16
+	MOVW	60(R20), R22
+	ADDU	R22, R17, R17
+
+	// XOR with input bytes (LE byte-swap on big-endian) and store.
+	MOVW	0(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R2, R2
+	WSBH	R2, R2
+	ROTR	$16, R2, R2
+	MOVW	R2, 0(R18)
+
+	MOVW	4(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R3, R3
+	WSBH	R3, R3
+	ROTR	$16, R3, R3
+	MOVW	R3, 4(R18)
+
+	MOVW	8(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R4, R4
+	WSBH	R4, R4
+	ROTR	$16, R4, R4
+	MOVW	R4, 8(R18)
+
+	MOVW	12(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R5, R5
+	WSBH	R5, R5
+	ROTR	$16, R5, R5
+	MOVW	R5, 12(R18)
+
+	MOVW	16(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R6, R6
+	WSBH	R6, R6
+	ROTR	$16, R6, R6
+	MOVW	R6, 16(R18)
+
+	MOVW	20(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R7, R7
+	WSBH	R7, R7
+	ROTR	$16, R7, R7
+	MOVW	R7, 20(R18)
+
+	MOVW	24(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R8, R8
+	WSBH	R8, R8
+	ROTR	$16, R8, R8
+	MOVW	R8, 24(R18)
+
+	MOVW	28(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R9, R9
+	WSBH	R9, R9
+	ROTR	$16, R9, R9
+	MOVW	R9, 28(R18)
+
+	MOVW	32(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R10, R10
+	WSBH	R10, R10
+	ROTR	$16, R10, R10
+	MOVW	R10, 32(R18)
+
+	MOVW	36(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R11, R11
+	WSBH	R11, R11
+	ROTR	$16, R11, R11
+	MOVW	R11, 36(R18)
+
+	MOVW	40(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R12, R12
+	WSBH	R12, R12
+	ROTR	$16, R12, R12
+	MOVW	R12, 40(R18)
+
+	MOVW	44(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R13, R13
+	WSBH	R13, R13
+	ROTR	$16, R13, R13
+	MOVW	R13, 44(R18)
+
+	MOVW	48(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R14, R14
+	WSBH	R14, R14
+	ROTR	$16, R14, R14
+	MOVW	R14, 48(R18)
+
+	MOVW	52(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R15, R15
+	WSBH	R15, R15
+	ROTR	$16, R15, R15
+	MOVW	R15, 52(R18)
+
+	MOVW	56(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R16, R16
+	WSBH	R16, R16
+	ROTR	$16, R16, R16
+	MOVW	R16, 56(R18)
+
+	MOVW	60(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R17, R17
+	WSBH	R17, R17
+	ROTR	$16, R17, R17
+	MOVW	R17, 60(R18)
+
+	// Bump the in-memory counter.
+	MOVW	48(R20), R22
+	ADDU	$1, R22, R22
+	MOVW	R22, 48(R20)
+
+	ADDU	$64, R18
+	ADDU	$64, R19
+	SUBU	$1, R21
+	BNE	R21, block_loop
+
+done:
+	RET

--- a/tsasm/mips32/chacha20/chacha20_mips_le.s
+++ b/tsasm/mips32/chacha20/chacha20_mips_le.s
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mipsle
+
+#include "textflag.h"
+
+// chacha20BlocksASM(out, in unsafe.Pointer, state *[16]uint32, blocks uintptr)
+//
+// 32-bit MIPS r2 (Plan 9 syntax) port of the mips64 ChaCha20 inner
+// loop in tsasm/mips64/chacha20/chacha20_mips64.s.  The algorithm
+// is unchanged: 16 32-bit state words live in registers (R2..R17)
+// across the 20 rounds, rotates use MIPS r2 ROTR, and the LE byte
+// swap on input/output uses WSBH+ROTR16. The differences from the
+// mips64 port are mechanical:
+//   * 4-byte args, frame layout uses MOVW for pointer loads.
+//   * 4-byte pointer increments via ADDU instead of ADDV.
+//   * Block counter decrement via SUBU instead of SUBVU.
+//
+// Register usage is identical to the mips64 port; see that file for
+// the rationale.
+TEXT ·chacha20BlocksASM(SB), NOSPLIT|NOFRAME, $0-16
+	MOVW	out+0(FP), R18
+	MOVW	in+4(FP), R19
+	MOVW	state+8(FP), R20
+	MOVW	blocks+12(FP), R21
+
+	BEQ	R21, done
+
+block_loop:
+	MOVW	0(R20), R2
+	MOVW	4(R20), R3
+	MOVW	8(R20), R4
+	MOVW	12(R20), R5
+	MOVW	16(R20), R6
+	MOVW	20(R20), R7
+	MOVW	24(R20), R8
+	MOVW	28(R20), R9
+	MOVW	32(R20), R10
+	MOVW	36(R20), R11
+	MOVW	40(R20), R12
+	MOVW	44(R20), R13
+	MOVW	48(R20), R14
+	MOVW	52(R20), R15
+	MOVW	56(R20), R16
+	MOVW	60(R20), R17
+
+	MOVW	$10, R24
+
+round_loop:
+	// Column round.
+	ADDU	R6, R2, R2
+	XOR	R2, R14, R14
+	ROTR	$16, R14, R14
+	ADDU	R14, R10, R10
+	XOR	R10, R6, R6
+	ROTR	$20, R6, R6
+	ADDU	R6, R2, R2
+	XOR	R2, R14, R14
+	ROTR	$24, R14, R14
+	ADDU	R14, R10, R10
+	XOR	R10, R6, R6
+	ROTR	$25, R6, R6
+
+	ADDU	R7, R3, R3
+	XOR	R3, R15, R15
+	ROTR	$16, R15, R15
+	ADDU	R15, R11, R11
+	XOR	R11, R7, R7
+	ROTR	$20, R7, R7
+	ADDU	R7, R3, R3
+	XOR	R3, R15, R15
+	ROTR	$24, R15, R15
+	ADDU	R15, R11, R11
+	XOR	R11, R7, R7
+	ROTR	$25, R7, R7
+
+	ADDU	R8, R4, R4
+	XOR	R4, R16, R16
+	ROTR	$16, R16, R16
+	ADDU	R16, R12, R12
+	XOR	R12, R8, R8
+	ROTR	$20, R8, R8
+	ADDU	R8, R4, R4
+	XOR	R4, R16, R16
+	ROTR	$24, R16, R16
+	ADDU	R16, R12, R12
+	XOR	R12, R8, R8
+	ROTR	$25, R8, R8
+
+	ADDU	R9, R5, R5
+	XOR	R5, R17, R17
+	ROTR	$16, R17, R17
+	ADDU	R17, R13, R13
+	XOR	R13, R9, R9
+	ROTR	$20, R9, R9
+	ADDU	R9, R5, R5
+	XOR	R5, R17, R17
+	ROTR	$24, R17, R17
+	ADDU	R17, R13, R13
+	XOR	R13, R9, R9
+	ROTR	$25, R9, R9
+
+	// Diagonal round.
+	ADDU	R7, R2, R2
+	XOR	R2, R17, R17
+	ROTR	$16, R17, R17
+	ADDU	R17, R12, R12
+	XOR	R12, R7, R7
+	ROTR	$20, R7, R7
+	ADDU	R7, R2, R2
+	XOR	R2, R17, R17
+	ROTR	$24, R17, R17
+	ADDU	R17, R12, R12
+	XOR	R12, R7, R7
+	ROTR	$25, R7, R7
+
+	ADDU	R8, R3, R3
+	XOR	R3, R14, R14
+	ROTR	$16, R14, R14
+	ADDU	R14, R13, R13
+	XOR	R13, R8, R8
+	ROTR	$20, R8, R8
+	ADDU	R8, R3, R3
+	XOR	R3, R14, R14
+	ROTR	$24, R14, R14
+	ADDU	R14, R13, R13
+	XOR	R13, R8, R8
+	ROTR	$25, R8, R8
+
+	ADDU	R9, R4, R4
+	XOR	R4, R15, R15
+	ROTR	$16, R15, R15
+	ADDU	R15, R10, R10
+	XOR	R10, R9, R9
+	ROTR	$20, R9, R9
+	ADDU	R9, R4, R4
+	XOR	R4, R15, R15
+	ROTR	$24, R15, R15
+	ADDU	R15, R10, R10
+	XOR	R10, R9, R9
+	ROTR	$25, R9, R9
+
+	ADDU	R6, R5, R5
+	XOR	R5, R16, R16
+	ROTR	$16, R16, R16
+	ADDU	R16, R11, R11
+	XOR	R11, R6, R6
+	ROTR	$20, R6, R6
+	ADDU	R6, R5, R5
+	XOR	R5, R16, R16
+	ROTR	$24, R16, R16
+	ADDU	R16, R11, R11
+	XOR	R11, R6, R6
+	ROTR	$25, R6, R6
+
+	SUBU	$1, R24
+	BNE	R24, round_loop
+
+	// x[i] += state[i].
+	MOVW	0(R20), R22
+	ADDU	R22, R2, R2
+	MOVW	4(R20), R22
+	ADDU	R22, R3, R3
+	MOVW	8(R20), R22
+	ADDU	R22, R4, R4
+	MOVW	12(R20), R22
+	ADDU	R22, R5, R5
+	MOVW	16(R20), R22
+	ADDU	R22, R6, R6
+	MOVW	20(R20), R22
+	ADDU	R22, R7, R7
+	MOVW	24(R20), R22
+	ADDU	R22, R8, R8
+	MOVW	28(R20), R22
+	ADDU	R22, R9, R9
+	MOVW	32(R20), R22
+	ADDU	R22, R10, R10
+	MOVW	36(R20), R22
+	ADDU	R22, R11, R11
+	MOVW	40(R20), R22
+	ADDU	R22, R12, R12
+	MOVW	44(R20), R22
+	ADDU	R22, R13, R13
+	MOVW	48(R20), R22
+	ADDU	R22, R14, R14
+	MOVW	52(R20), R22
+	ADDU	R22, R15, R15
+	MOVW	56(R20), R22
+	ADDU	R22, R16, R16
+	MOVW	60(R20), R22
+	ADDU	R22, R17, R17
+
+	// XOR with input bytes (LE byte-swap on big-endian) and store.
+	MOVW	0(R19), R22
+	XOR	R22, R2, R2
+	MOVW	R2, 0(R18)
+
+	MOVW	4(R19), R22
+	XOR	R22, R3, R3
+	MOVW	R3, 4(R18)
+
+	MOVW	8(R19), R22
+	XOR	R22, R4, R4
+	MOVW	R4, 8(R18)
+
+	MOVW	12(R19), R22
+	XOR	R22, R5, R5
+	MOVW	R5, 12(R18)
+
+	MOVW	16(R19), R22
+	XOR	R22, R6, R6
+	MOVW	R6, 16(R18)
+
+	MOVW	20(R19), R22
+	XOR	R22, R7, R7
+	MOVW	R7, 20(R18)
+
+	MOVW	24(R19), R22
+	XOR	R22, R8, R8
+	MOVW	R8, 24(R18)
+
+	MOVW	28(R19), R22
+	XOR	R22, R9, R9
+	MOVW	R9, 28(R18)
+
+	MOVW	32(R19), R22
+	XOR	R22, R10, R10
+	MOVW	R10, 32(R18)
+
+	MOVW	36(R19), R22
+	XOR	R22, R11, R11
+	MOVW	R11, 36(R18)
+
+	MOVW	40(R19), R22
+	XOR	R22, R12, R12
+	MOVW	R12, 40(R18)
+
+	MOVW	44(R19), R22
+	XOR	R22, R13, R13
+	MOVW	R13, 44(R18)
+
+	MOVW	48(R19), R22
+	XOR	R22, R14, R14
+	MOVW	R14, 48(R18)
+
+	MOVW	52(R19), R22
+	XOR	R22, R15, R15
+	MOVW	R15, 52(R18)
+
+	MOVW	56(R19), R22
+	XOR	R22, R16, R16
+	MOVW	R16, 56(R18)
+
+	MOVW	60(R19), R22
+	XOR	R22, R17, R17
+	MOVW	R17, 60(R18)
+
+	// Bump the in-memory counter.
+	MOVW	48(R20), R22
+	ADDU	$1, R22, R22
+	MOVW	R22, 48(R20)
+
+	ADDU	$64, R18
+	ADDU	$64, R19
+	SUBU	$1, R21
+	BNE	R21, block_loop
+
+done:
+	RET

--- a/tsasm/mips32/chacha20/chacha20_test.go
+++ b/tsasm/mips32/chacha20/chacha20_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips || mipsle
+
+package chacha20
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	xchacha "golang.org/x/crypto/chacha20"
+)
+
+// RFC 8439 §2.4.2 test vector.
+func TestRFC8439Vector(t *testing.T) {
+	keyHex := "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+	nonceHex := "000000000000004a00000000"
+	const counter = 1
+	src := "Ladies and Gentlemen of the class of '99: " +
+		"If I could offer you only one tip for the future, sunscreen would be it."
+	plaintext := make([]byte, len(src))
+	copy(plaintext, src)
+	wantHex := "" +
+		"6e2e359a2568f98041ba0728dd0d6981" +
+		"e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab" +
+		"8f593dabcd62b3571639d624e65152ab8f530c359f0861d8" +
+		"07ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806" +
+		"818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42" +
+		"874d"
+
+	var key [32]byte
+	mustHex(t, key[:], keyHex)
+	var nonce [12]byte
+	mustHex(t, nonce[:], nonceHex)
+	want := mustHexBytes(t, wantHex)
+
+	out := make([]byte, len(plaintext))
+	XORKeyStream(out, plaintext, &key, &nonce, counter)
+
+	if !bytes.Equal(out, want) {
+		t.Fatalf("RFC 8439 vector mismatch:\n got %x\nwant %x", out, want)
+	}
+}
+
+func TestAgainstReference(t *testing.T) {
+	var key [32]byte
+	var nonce [12]byte
+	rand.Read(key[:])
+	rand.Read(nonce[:])
+
+	for _, n := range []int{0, 1, 16, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 511, 512, 1024, 1500, 4096} {
+		t.Run(fmt.Sprintf("len=%d", n), func(t *testing.T) {
+			in := make([]byte, n)
+			rand.Read(in)
+			got := make([]byte, n)
+			want := make([]byte, n)
+
+			XORKeyStream(got, in, &key, &nonce, 0)
+
+			c, err := xchacha.NewUnauthenticatedCipher(key[:], nonce[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.XORKeyStream(want, in)
+
+			if !bytes.Equal(got, want) {
+				t.Errorf("mismatch (n=%d):\n got %x\nwant %x", n, got, want)
+			}
+		})
+	}
+}
+
+func mustHex(t *testing.T, dst []byte, s string) {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) != len(dst) {
+		t.Fatalf("hex length %d, want %d", len(b), len(dst))
+	}
+	copy(dst, b)
+}
+
+func mustHexBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// BenchmarkXORKeyStream measures pure ChaCha20 throughput at a
+// typical WireGuard data-packet size (1420 bytes), comparing the
+// asm path against pure-Go.
+func BenchmarkXORKeyStream(b *testing.B) {
+	for _, size := range []int{64, 256, 1420, 8192} {
+		var key [32]byte
+		var nonce [12]byte
+		in := make([]byte, size)
+		out := make([]byte, size)
+		b.Run(fmt.Sprintf("%d/asm", size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				XORKeyStream(out, in, &key, &nonce, 0)
+			}
+		})
+		b.Run(fmt.Sprintf("%d/xcrypto", size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				c, _ := xchacha.NewUnauthenticatedCipher(key[:], nonce[:])
+				c.XORKeyStream(out, in)
+			}
+		})
+	}
+}

--- a/tsasm/mips32/chacha20poly1305/aead_compat_test.go
+++ b/tsasm/mips32/chacha20poly1305/aead_compat_test.go
@@ -1,0 +1,232 @@
+//go:build mips || mipsle
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package chacha20poly1305
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+
+	xchacha20poly1305 "golang.org/x/crypto/chacha20poly1305"
+)
+
+type aeadCtorEntry struct {
+	name string
+	new  func(key []byte) (cipher.AEAD, error)
+}
+
+var aeadCtors = []aeadCtorEntry{
+	{"go-chacha20poly1305", xchacha20poly1305.New},
+	{"asm-chacha20poly1305", New},
+}
+
+func mustHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestAEAD_RFC8439Vector(t *testing.T) {
+	key := mustHex("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f")
+	nonce := mustHex("070000004041424344454647")
+	aad := mustHex("50515253c0c1c2c3c4c5c6c7")
+	src := "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."
+	plaintext := make([]byte, len(src))
+	copy(plaintext, src)
+	wantCT := mustHex("d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116")
+	wantTag := mustHex("1ae10b594f09e26a7e902ecbd0600691")
+	want := append(append([]byte{}, wantCT...), wantTag...)
+
+	for _, c := range aeadCtors {
+		t.Run(c.name, func(t *testing.T) {
+			aead, err := c.new(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := aead.Seal(nil, nonce, plaintext, aad)
+			if !bytes.Equal(got, want) {
+				t.Errorf("Seal mismatch:\n got: %x\nwant: %x", got, want)
+			}
+			opened, err := aead.Open(nil, nonce, want, aad)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			if !bytes.Equal(opened, plaintext) {
+				t.Errorf("Open mismatch:\n got: %q\nwant: %q", opened, plaintext)
+			}
+		})
+	}
+}
+
+func TestAEAD_AgreesWithReference(t *testing.T) {
+	sizes := []int{0, 1, 15, 16, 17, 31, 63, 64, 65, 127, 128, 1024, 1500, 4096}
+	aadSizes := []int{0, 1, 13, 64}
+
+	var key [32]byte
+	rand.Read(key[:])
+	var nonce [12]byte
+	rand.Read(nonce[:])
+
+	ref, err := xchacha20poly1305.New(key[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range aeadCtors {
+		aead, err := c.new(key[:])
+		if err != nil {
+			t.Fatalf("%s: New: %v", c.name, err)
+		}
+		for _, plen := range sizes {
+			plaintext := make([]byte, plen)
+			rand.Read(plaintext)
+			for _, alen := range aadSizes {
+				aad := make([]byte, alen)
+				rand.Read(aad)
+				wantCT := ref.Seal(nil, nonce[:], plaintext, aad)
+				name := fmt.Sprintf("%s/pt=%d/aad=%d", c.name, plen, alen)
+				t.Run(name, func(t *testing.T) {
+					gotCT := aead.Seal(nil, nonce[:], plaintext, aad)
+					if !bytes.Equal(gotCT, wantCT) {
+						t.Fatalf("Seal mismatch")
+					}
+					pt, err := aead.Open(nil, nonce[:], wantCT, aad)
+					if err != nil {
+						t.Fatalf("Open: %v", err)
+					}
+					if !bytes.Equal(pt, plaintext) {
+						t.Fatalf("Open mismatch")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAEAD_OpenRejectsTamper(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+	var nonce [12]byte
+	rand.Read(nonce[:])
+	src := "the quick brown fox jumps over the lazy dog"
+	plaintext := make([]byte, len(src))
+	copy(plaintext, src)
+	aad := []byte("metadata")
+
+	for _, c := range aeadCtors {
+		t.Run(c.name, func(t *testing.T) {
+			aead, err := c.new(key[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			ct := aead.Seal(nil, nonce[:], plaintext, aad)
+
+			tamper := append([]byte{}, ct...)
+			tamper[0] ^= 1
+			if _, err := aead.Open(nil, nonce[:], tamper, aad); err == nil {
+				t.Error("Open accepted tampered ciphertext")
+			}
+
+			tamper = append([]byte{}, ct...)
+			tamper[len(tamper)-1] ^= 1
+			if _, err := aead.Open(nil, nonce[:], tamper, aad); err == nil {
+				t.Error("Open accepted tampered tag")
+			}
+		})
+	}
+}
+
+func TestAEAD_Concurrent(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+	plaintext := []byte("wireguard concurrent aead test")
+	aad := []byte("aad")
+
+	for _, c := range aeadCtors {
+		t.Run(c.name, func(t *testing.T) {
+			aead, err := c.new(key[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			const goroutines = 4
+			const iters = 50
+			var wg sync.WaitGroup
+			wg.Add(goroutines)
+			errs := make(chan error, goroutines)
+			for g := range goroutines {
+				go func(id int) {
+					defer wg.Done()
+					var nonce [12]byte
+					binary.BigEndian.PutUint64(nonce[4:], uint64(id))
+					for i := range iters {
+						binary.BigEndian.PutUint32(nonce[:4], uint32(i))
+						ct := aead.Seal(nil, nonce[:], plaintext, aad)
+						pt, err := aead.Open(nil, nonce[:], ct, aad)
+						if err != nil {
+							errs <- fmt.Errorf("goroutine %d iter %d: Open: %w", id, i, err)
+							return
+						}
+						if !bytes.Equal(pt, plaintext) {
+							errs <- fmt.Errorf("goroutine %d iter %d: plaintext mismatch", id, i)
+							return
+						}
+					}
+				}(g)
+			}
+			wg.Wait()
+			close(errs)
+			for err := range errs {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func BenchmarkAEAD_Seal(b *testing.B) { benchmarkAEAD(b, false) }
+func BenchmarkAEAD_Open(b *testing.B) { benchmarkAEAD(b, true) }
+
+func benchmarkAEAD(b *testing.B, open bool) {
+	const ptSize = 1420
+	var key [32]byte
+	rand.Read(key[:])
+	var nonce [12]byte
+	plaintext := make([]byte, ptSize)
+	rand.Read(plaintext)
+
+	for _, c := range aeadCtors {
+		b.Run(c.name, func(b *testing.B) {
+			aead, err := c.new(key[:])
+			if err != nil {
+				b.Fatal(err)
+			}
+			ctBuf := make([]byte, 0, ptSize+aead.Overhead())
+			ct := aead.Seal(ctBuf, nonce[:], plaintext, nil)
+			ptBuf := make([]byte, 0, ptSize)
+			b.SetBytes(int64(ptSize))
+			b.ResetTimer()
+			if open {
+				for range b.N {
+					if _, err := aead.Open(ptBuf[:0], nonce[:], ct, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			} else {
+				for range b.N {
+					_ = aead.Seal(ctBuf[:0], nonce[:], plaintext, nil)
+				}
+			}
+		})
+	}
+}

--- a/tsasm/mips32/chacha20poly1305/chacha20poly1305.go
+++ b/tsasm/mips32/chacha20poly1305/chacha20poly1305.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips || mipsle
+
+// Package chacha20poly1305 provides a ChaCha20-Poly1305 AEAD that
+// pairs the hand-ported scalar mips32r2 ChaCha20 in
+// tsasm/mips32/chacha20 with the matching scalar Poly1305 in
+// tsasm/mips32/poly1305 (a port of openssl/Linux poly1305-mips.pl's
+// 32-bit non-MADDU code path). Both halves are asm here.
+//
+// Only builds on GOARCH=mips / mipsle; other architectures should
+// use golang.org/x/crypto/chacha20poly1305 directly.
+package chacha20poly1305
+
+import (
+	"crypto/cipher"
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+
+	chacha "github.com/tailscale/wireguard-go/tsasm/mips32/chacha20"
+	"github.com/tailscale/wireguard-go/tsasm/mips32/poly1305"
+)
+
+const (
+	KeySize   = 32
+	NonceSize = 12
+	Overhead  = 16
+)
+
+type aead struct {
+	key [KeySize]byte
+}
+
+func New(key []byte) (cipher.AEAD, error) {
+	if len(key) != KeySize {
+		return nil, errors.New("chacha20poly1305: bad key length")
+	}
+	a := &aead{}
+	copy(a.key[:], key)
+	return a, nil
+}
+
+func (a *aead) NonceSize() int { return NonceSize }
+func (a *aead) Overhead() int  { return Overhead }
+
+func (a *aead) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
+	if len(nonce) != NonceSize {
+		panic("chacha20poly1305: bad nonce length")
+	}
+	ret, out := sliceForAppend(dst, len(plaintext)+Overhead)
+
+	var nonceArr [chacha.NonceSize]byte
+	copy(nonceArr[:], nonce)
+
+	var (
+		zeros   [64]byte
+		polyBuf [64]byte
+		polyKey [32]byte
+	)
+	chacha.XORKeyStream(polyBuf[:], zeros[:], &a.key, &nonceArr, 0)
+	copy(polyKey[:], polyBuf[:32])
+	chacha.XORKeyStream(out[:len(plaintext)], plaintext, &a.key, &nonceArr, 1)
+
+	tag := computeTag(additionalData, out[:len(plaintext)], &polyKey)
+	copy(out[len(plaintext):], tag[:])
+	return ret
+}
+
+func (a *aead) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	if len(nonce) != NonceSize {
+		return nil, errors.New("chacha20poly1305: bad nonce length")
+	}
+	if len(ciphertext) < Overhead {
+		return nil, errors.New("chacha20poly1305: ciphertext too short")
+	}
+	ctLen := len(ciphertext) - Overhead
+	ct := ciphertext[:ctLen]
+	receivedTag := ciphertext[ctLen:]
+
+	var nonceArr [chacha.NonceSize]byte
+	copy(nonceArr[:], nonce)
+
+	var (
+		zeros   [64]byte
+		polyBuf [64]byte
+		polyKey [32]byte
+	)
+	chacha.XORKeyStream(polyBuf[:], zeros[:], &a.key, &nonceArr, 0)
+	copy(polyKey[:], polyBuf[:32])
+
+	expectedTag := computeTag(additionalData, ct, &polyKey)
+	if subtle.ConstantTimeCompare(receivedTag, expectedTag[:]) != 1 {
+		return nil, errors.New("chacha20poly1305: message authentication failed")
+	}
+
+	ret, out := sliceForAppend(dst, ctLen)
+	chacha.XORKeyStream(out, ct, &a.key, &nonceArr, 1)
+	return ret, nil
+}
+
+var zeros16 [16]byte
+
+func computeTag(aad, ct []byte, polyKey *[32]byte) [16]byte {
+	var mac poly1305.MAC
+	mac.Init(polyKey)
+	mac.Write(aad)
+	if rem := len(aad) % 16; rem != 0 {
+		mac.Write(zeros16[:16-rem])
+	}
+	mac.Write(ct)
+	if rem := len(ct) % 16; rem != 0 {
+		mac.Write(zeros16[:16-rem])
+	}
+	var lenBuf [16]byte
+	binary.LittleEndian.PutUint64(lenBuf[0:8], uint64(len(aad)))
+	binary.LittleEndian.PutUint64(lenBuf[8:16], uint64(len(ct)))
+	mac.Write(lenBuf[:])
+
+	var tag [16]byte
+	mac.Sum(&tag)
+	return tag
+}
+
+func sliceForAppend(dst []byte, n int) (head, tail []byte) {
+	if total := len(dst) + n; cap(dst) >= total {
+		head = dst[:total]
+	} else {
+		head = make([]byte, total)
+		copy(head, dst)
+	}
+	tail = head[len(dst):]
+	return
+}

--- a/tsasm/mips32/poly1305/poly1305_mips32.go
+++ b/tsasm/mips32/poly1305/poly1305_mips32.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips || mipsle
+
+// Package poly1305 implements Poly1305 with a hand-written scalar
+// mips32r2 inner loop modeled on Andy Polyakov's poly1305-mips.pl
+// (the 32-bit code path; openssl/Linux upstream).
+//
+// The state is held in 5 saturated 32-bit limbs of h
+// (h = h0 + h1*2^32 + h2*2^64 + h3*2^96 + h4*2^128, h4 carries the
+// few bits at and above 2^128), 4 saturated 32-bit limbs of the
+// clamped key r, plus precomputed s_i = r_i + (r_i >> 2) for i in
+// 1..3 to absorb the 2^130 ≡ 5 reduction inside the inner loop.
+//
+// The inner loop is the upstream non-MADDU variant: 20 individual
+// MULTU partial products, each followed by MFLO + MFHI and a
+// manual ADDU + SLTU carry chain. No MADDU-into-accumulator -- my
+// earlier 5x26 + MULU/MADDU layout matched the pure-Go mirror in
+// algorithm-vs-algorithm tests but gave occasional wrong tags
+// (~7%) on real Cavium Octeon II and Ingenic JZ4780 silicon.
+// MULTU/MFLO/MFHI without intervening MADDUs sidesteps any
+// hazard between successive HI/LO writers entirely.
+//
+// Builds on both GOARCH=mips (BE) and GOARCH=mipsle (LE). The
+// shared Go wrapper drives the right BE-only / LE-only .s file via
+// build tags. mipsle is hardware-validated on the Ingenic CI20
+// (kernel 3.18); mips BE has no hardware available so it is
+// build-only.
+package poly1305
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+const (
+	KeySize = 32
+	TagSize = 16
+)
+
+// macState matches the upstream poly1305-mips.pl 32-bit ctx layout:
+//
+//	offset  0: h0    offset 20: r0    offset 36: s1
+//	offset  4: h1    offset 24: r1    offset 40: s2
+//	offset  8: h2    offset 28: r2    offset 44: s3
+//	offset 12: h3    offset 32: r3
+//	offset 16: h4
+//
+// The asm hard-codes these offsets.
+type macState struct {
+	h [5]uint32 // saturated 32-bit limbs of the running hash
+	r [4]uint32 // saturated 32-bit limbs of the clamped key
+	s [3]uint32 // s[i-1] = r[i] + (r[i] >> 2) for i in 1..3
+}
+
+// MAC is an incremental Poly1305 message-authentication code computer.
+// Single-use; not safe for concurrent use. Zero-value is not usable --
+// call Init first.
+type MAC struct {
+	state  macState
+	pad    [4]uint32 // saved key[16:32], added in Sum.
+	buffer [TagSize]byte
+	offset int
+}
+
+// New returns a fresh MAC keyed with key. Prefer (*MAC).Init for hot
+// paths; this constructor heap-allocates.
+func New(key *[KeySize]byte) *MAC {
+	m := new(MAC)
+	m.Init(key)
+	return m
+}
+
+// Init keys an existing (typically stack-allocated) MAC with key.
+// Clamps r per RFC 8439 (mask 0x0ffffffc0ffffffc0ffffffc0fffffff).
+func (m *MAC) Init(key *[KeySize]byte) {
+	*m = MAC{}
+	r0 := binary.LittleEndian.Uint32(key[0:4]) & 0x0FFFFFFF
+	r1 := binary.LittleEndian.Uint32(key[4:8]) & 0x0FFFFFFC
+	r2 := binary.LittleEndian.Uint32(key[8:12]) & 0x0FFFFFFC
+	r3 := binary.LittleEndian.Uint32(key[12:16]) & 0x0FFFFFFC
+	m.state.r[0] = r0
+	m.state.r[1] = r1
+	m.state.r[2] = r2
+	m.state.r[3] = r3
+	m.state.s[0] = r1 + (r1 >> 2)
+	m.state.s[1] = r2 + (r2 >> 2)
+	m.state.s[2] = r3 + (r3 >> 2)
+	m.pad[0] = binary.LittleEndian.Uint32(key[16:20])
+	m.pad[1] = binary.LittleEndian.Uint32(key[20:24])
+	m.pad[2] = binary.LittleEndian.Uint32(key[24:28])
+	m.pad[3] = binary.LittleEndian.Uint32(key[28:32])
+}
+
+// poly1305Update processes blocks 16-byte chunks of msg into state.
+// padbit is 1 for full blocks (the implicit 1 at bit 128) or 0 for
+// the last partial block, which the caller has already padded with
+// a 0x01 byte.
+//
+//go:noescape
+func poly1305Update(state *macState, msg unsafe.Pointer, blocks uintptr, padbit uintptr)
+
+// Write feeds bytes into the MAC. Returns len(p), nil.
+func (m *MAC) Write(p []byte) (int, error) {
+	n := len(p)
+	if m.offset > 0 {
+		k := copy(m.buffer[m.offset:], p)
+		m.offset += k
+		if m.offset == TagSize {
+			poly1305Update(&m.state, unsafe.Pointer(&m.buffer[0]), 1, 1)
+			m.offset = 0
+		}
+		p = p[k:]
+	}
+	if blocks := len(p) / TagSize; blocks > 0 {
+		poly1305Update(&m.state, unsafe.Pointer(&p[0]), uintptr(blocks), 1)
+		p = p[blocks*TagSize:]
+	}
+	if len(p) > 0 {
+		m.offset = copy(m.buffer[:], p)
+	}
+	return n, nil
+}
+
+// Sum flushes any buffered partial block and writes the 16-byte tag
+// to out. Sum may be called multiple times; it does not consume the
+// state.
+func (m *MAC) Sum(out *[TagSize]byte) {
+	state := m.state
+	if m.offset > 0 {
+		var buf [TagSize]byte
+		copy(buf[:], m.buffer[:m.offset])
+		buf[m.offset] = 1
+		poly1305Update(&state, unsafe.Pointer(&buf[0]), 1, 0)
+	}
+	finalize(out, &state.h, &m.pad)
+}
+
+// Sum computes a Poly1305 MAC of m under key, writing the 16-byte tag
+// to out.
+func Sum(out *[TagSize]byte, m []byte, key *[KeySize]byte) {
+	var mac MAC
+	mac.Init(key)
+	mac.Write(m)
+	mac.Sum(out)
+}
+
+// finalize fully reduces h mod (2^130 - 5), adds the pad, and emits
+// the 16-byte tag in little-endian byte order.
+//
+// Like the mips64 sibling, the asm leaves h4 holding the running
+// limb 4 value at end of inner loop -- upstream's modulo-scheduled
+// reduction lives at *block start*, so finalize replays it once
+// more before subtracting p. After that h4 is in canonical 0..4
+// range and the standard saturated-32 tail (subtract p,
+// constant-time select, add pad) takes over.
+func finalize(out *[TagSize]byte, h *[5]uint32, pad *[4]uint32) {
+	h0, h1, h2, h3, h4 := h[0], h[1], h[2], h[3], h[4]
+
+	// One more modulo-scheduled fold of h4's high bits back via *5.
+	high := h4 >> 2
+	h4 &= 3
+	// residue = high * 5 = high*4 + high. high*4 (= high<<2) fits in
+	// 32 bits since h4 < 2^32 implies high < 2^30. So high*5 fits
+	// in 33 bits; track with a small carry.
+	res4 := high << 2 // < 2^32
+	resCarry := high >> 30
+	residue, c := bitsAdd32(res4, high, 0)
+	resCarry += c
+
+	h0, c = bitsAdd32(h0, residue, 0)
+	h1, c = bitsAdd32(h1, resCarry, c)
+	h2, c = bitsAdd32(h2, 0, c)
+	h3, c = bitsAdd32(h3, 0, c)
+	h4 += c
+
+	// Compute t = h - p where p = 2^130 - 5; if no borrow, h >= p.
+	const (
+		p0 uint32 = 0xFFFFFFFB
+		p1 uint32 = 0xFFFFFFFF
+		p2 uint32 = 0xFFFFFFFF
+		p3 uint32 = 0xFFFFFFFF
+		p4 uint32 = 0x00000003
+	)
+	var b uint32
+	t0, b := bitsSub32(h0, p0, 0)
+	var t1, t2, t3 uint32
+	t1, b = bitsSub32(h1, p1, b)
+	t2, b = bitsSub32(h2, p2, b)
+	t3, b = bitsSub32(h3, p3, b)
+	_, b = bitsSub32(h4, p4, b)
+
+	// Constant-time select: keep h if h < p (b=1), else use t.
+	h0 = select32(b, h0, t0)
+	h1 = select32(b, h1, t1)
+	h2 = select32(b, h2, t2)
+	h3 = select32(b, h3, t3)
+
+	// tag = (h + pad) mod 2^128. pad is 4 LE u32 from key[16:32].
+	h0, c = bitsAdd32(h0, pad[0], 0)
+	h1, c = bitsAdd32(h1, pad[1], c)
+	h2, c = bitsAdd32(h2, pad[2], c)
+	h3, _ = bitsAdd32(h3, pad[3], c)
+
+	binary.LittleEndian.PutUint32(out[0:], h0)
+	binary.LittleEndian.PutUint32(out[4:], h1)
+	binary.LittleEndian.PutUint32(out[8:], h2)
+	binary.LittleEndian.PutUint32(out[12:], h3)
+}
+
+// bitsAdd32 / bitsSub32 / select32 are the 32-bit equivalents of
+// math/bits.{Add64,Sub64} and the standard constant-time select
+// pattern; inlined here to avoid the broader math/bits dependency
+// on this package and to keep the implementation transparent.
+
+func bitsAdd32(x, y, carry uint32) (sum, carryOut uint32) {
+	sum = x + y + carry
+	carryOut = ((x & y) | ((x | y) & ^sum)) >> 31
+	return
+}
+
+func bitsSub32(x, y, borrow uint32) (diff, borrowOut uint32) {
+	diff = x - y - borrow
+	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 31
+	return
+}
+
+func select32(v, x, y uint32) uint32 {
+	mask := ^(v - 1)
+	return (x & mask) | (y & ^mask)
+}

--- a/tsasm/mips32/poly1305/poly1305_mips_be.s
+++ b/tsasm/mips32/poly1305/poly1305_mips_be.s
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips
+
+#include "textflag.h"
+
+// poly1305Update(state *macState, msg unsafe.Pointer, blocks uintptr, padbit uintptr)
+//
+// Hand-translated from openssl/Linux poly1305-mips.pl (Andy Polyakov,
+// dual-licensed BSD-3-Clause / OpenSSL); the 32-bit non-MADDU code
+// path. 5x32 saturated h, 4x32 saturated r, plus precomputed
+// s_i = r_i + (r_i >> 2) for i in 1..3 to fold the 2^130 ≡ 5
+// reduction into the multiplication.
+//
+// 20 partial products per 16-byte block. Each is MULTU + MFLO +
+// MFHI + manual ADDU/SLTU(SGTU) carry chain -- no MADDU into the
+// HI/LO accumulator. The earlier 5x26 attempt that DID use MADDU
+// gave occasional wrong tags (~7%) on real Cavium Octeon II and
+// Ingenic JZ4780 silicon; this layout avoids the multi-MADDU
+// chain entirely.
+//
+// LE variant: input is loaded with plain MOVW (LWU equivalent on
+// 32-bit MIPS); on a little-endian host that already gives an LE
+// u32. The BE variant in poly1305_mips_be.s adds a WSBH+ROTR16
+// pair after each input load.
+//
+// Register usage (Plan 9 names, MIPS o32 ABI labels in parens):
+//
+//   R16 (s0)  ctx ptr        R7  (a3)  r0
+//   R17 (s1)  msg ptr        R8  (t0)  r1
+//   R18 (s2)  blocks count   R9  (t1)  r2
+//   R19 (s3)  padbit         R10 (t2)  r3
+//                            R11 (t3)  s1
+//   R2  (v0)  h0             R12 (t4)  s2
+//   R3  (v1)  h1             R13 (t5)  s3
+//   R4  (a0)  h2
+//   R5  (a1)  h3             R14, R15, R20, R21  d0..d3
+//   R6  (a2)  h4             R24..R19  scratch (at, t0, t1, a3)
+//
+// R22 (REGCTXT) and R23 (REGTMP) are left alone.
+TEXT ·poly1305Update(SB), NOSPLIT, $0-16
+	MOVW	state+0(FP), R16
+	MOVW	msg+4(FP), R17
+	MOVW	blocks+8(FP), R18
+	MOVW	padbit+12(FP), R19
+
+	BEQ	R18, done
+
+	// Load h[0..4] and r[0..3] and s[1..3] from state.
+	MOVW	0(R16), R2     // h0
+	MOVW	4(R16), R3     // h1
+	MOVW	8(R16), R4     // h2
+	MOVW	12(R16), R5    // h3
+	MOVW	16(R16), R6    // h4
+	MOVW	20(R16), R7    // r0
+	MOVW	24(R16), R8    // r1
+	MOVW	28(R16), R9    // r2
+	MOVW	32(R16), R10   // r3
+	MOVW	36(R16), R11   // s1
+	MOVW	40(R16), R12   // s2
+	MOVW	44(R16), R13   // s3
+
+block_loop:
+	// padbit lives in R19 only briefly each block (ADDU R19, R6
+	// below); we then reuse R19 as the `a3` scratch slot to fit
+	// inside the no-R26/R27 register budget. Reload from the args
+	// frame at the top of every block.
+	MOVW	padbit+12(FP), R19
+
+	// Read 16 bytes of input as 4 LE u32 words. On mipsle, MOVW
+	// gives the LE value directly.
+	MOVW	0(R17), R14    // d0
+	WSBH	R14, R14
+	ROTR	$16, R14, R14
+	MOVW	4(R17), R15    // d1
+	WSBH	R15, R15
+	ROTR	$16, R15, R15
+	MOVW	8(R17), R20    // d2
+	WSBH	R20, R20
+	ROTR	$16, R20, R20
+	MOVW	12(R17), R21   // d3
+	WSBH	R21, R21
+	ROTR	$16, R21, R21
+
+	// Modulo-scheduled fold of h4's high bits back into h0 via *5
+	// before the input add.
+	SRL	$2, R6, R25    // t0 = h4 >> 2
+	AND	$3, R6, R6     // h4 &= 3
+	SLL	$2, R25, R24   // at = t0 * 4
+
+	// d0 = (in0 + h0) + (h4>>2)*5 (residue).
+	ADDU	R2, R14        // d0 += h0   (R14 = R2 + R14)
+	ADDU	R24, R25       // t0 += at  → t0 = (h4>>2)*5
+	SGTU	R2, R14, R2    // h0 = carry from d0 += h0_old (= h0_old > d0)
+	ADDU	R25, R14       // d0 += residue
+	SGTU	R25, R14, R24  // at = carry from d0 += residue
+
+	// d1 = in1 + h1 + carry-chain.
+	ADDU	R3, R15        // d1 += h1
+	ADDU	R24, R2        // h0 += at (combine carries)
+	SGTU	R3, R15, R3    // h1 = carry from d1 += h1
+	ADDU	R2, R15        // d1 += h0 (combined carry)
+	SGTU	R2, R15, R2    // h0 = carry from d1 += h0
+
+	// d2 = in2 + h2 + carry.
+	ADDU	R4, R20        // d2 += h2
+	ADDU	R2, R3         // h1 += h0 (combine)
+	SGTU	R4, R20, R4    // h2 = carry from d2 += h2
+	ADDU	R3, R20        // d2 += h1
+	SGTU	R3, R20, R3    // h1 = carry from d2 += h1
+
+	// d3 = in3 + h3 + carry.
+	ADDU	R5, R21        // d3 += h3
+	ADDU	R3, R4         // h2 += h1
+	SGTU	R5, R21, R5    // h3 = carry from d3 += h3
+	ADDU	R4, R21        // d3 += h2
+
+	// First multiply: d0 * r0.
+	MULU	R7, R14
+	SGTU	R4, R21, R4    // h2 = carry from d3 += h2 (final)
+	ADDU	R4, R5         // h3 += h2 (final carry into h3)
+	MOVW	LO, R2         // h0 = lo(d0*r0)
+	MOVW	HI, R3         // h1 = hi(d0*r0)
+
+	// Second multiply: d1 * s3.
+	MULU	R13, R15
+	ADDU	R19, R6        // h4 += padbit
+	ADDU	R5, R6         // h4 += h3 (final carry)
+	MOVW	LO, R24        // at = lo(d1*s3)
+	MOVW	HI, R25        // t0 = hi(d1*s3)
+
+	// Third multiply: d2 * s2.
+	MULU	R12, R20
+	MOVW	LO, R19        // a3 = lo(d2*s2)
+	MOVW	HI, R22        // t1 = hi(d2*s2)
+	ADDU	R24, R2        // h0 += at = lo(d1*s3)
+	ADDU	R25, R3        // h1 += t0 = hi(d1*s3)
+
+	// Fourth multiply: d3 * s1.
+	MULU	R11, R21
+	SGTU	R24, R2, R24   // at = carry from h0 += lo(d1*s3)
+	ADDU	R24, R3        // h1 += that carry
+	MOVW	LO, R24        // at = lo(d3*s1)
+	MOVW	HI, R25        // t0 = hi(d3*s1)
+	ADDU	R19, R2        // h0 += a3 = lo(d2*s2)
+	ADDU	R22, R3        // h1 += t1 = hi(d2*s2)
+
+	// Fifth multiply: d0 * r1.
+	MULU	R8, R14
+	SGTU	R19, R2, R19   // a3 = carry from h0 += lo(d2*s2)
+	ADDU	R19, R3        // h1 += that carry
+	MOVW	LO, R19        // a3 = lo(d0*r1)
+	MOVW	HI, R4         // h2 = hi(d0*r1)
+	ADDU	R24, R2        // h0 += at = lo(d3*s1)
+	ADDU	R25, R3        // h1 += t0 = hi(d3*s1)
+
+	// Sixth multiply: d1 * r0.
+	MULU	R7, R15
+	SGTU	R24, R2, R24   // at = carry from h0 += lo(d3*s1)
+	ADDU	R24, R3        // h1 += that carry
+	MOVW	LO, R24        // at = lo(d1*r0)
+	MOVW	HI, R25        // t0 = hi(d1*r0)
+	ADDU	R19, R3        // h1 += a3 = lo(d0*r1)
+	SGTU	R19, R3, R19   // a3 = carry from h1 += lo(d0*r1)
+
+	// Seventh multiply: d2 * s3.
+	MULU	R13, R20
+	ADDU	R19, R4        // h2 += that carry
+	MOVW	LO, R19        // a3 = lo(d2*s3)
+	MOVW	HI, R22        // t1 = hi(d2*s3)
+	ADDU	R24, R3        // h1 += at = lo(d1*r0)
+	ADDU	R25, R4        // h2 += t0 = hi(d1*r0)
+
+	// Eighth multiply: d3 * s2.
+	MULU	R12, R21
+	SGTU	R24, R3, R24   // at = carry from h1 += lo(d1*r0)
+	ADDU	R24, R4        // h2 += that carry
+	MOVW	LO, R24        // at = lo(d3*s2)
+	MOVW	HI, R25        // t0 = hi(d3*s2)
+	ADDU	R19, R3        // h1 += a3 = lo(d2*s3)
+	ADDU	R22, R4        // h2 += t1 = hi(d2*s3)
+
+	// Ninth multiply: h4 * s1. Bounded: h4 ≤ 5, s1 < 2^30, so
+	// product fits in LO and we ignore HI.
+	MULU	R11, R6
+	SGTU	R19, R3, R19   // a3 = carry from h1 += lo(d2*s3)
+	ADDU	R19, R4        // h2 += that carry
+	MOVW	LO, R19        // a3 = lo(h4*s1)
+	ADDU	R24, R3        // h1 += at = lo(d3*s2)
+	ADDU	R25, R4        // h2 += t0 = hi(d3*s2)
+
+	// Tenth multiply: d0 * r2.
+	MULU	R9, R14
+	SGTU	R24, R3, R24   // at = carry from h1 += lo(d3*s2)
+	ADDU	R24, R4        // h2 += that carry
+	MOVW	LO, R24        // at = lo(d0*r2)
+	MOVW	HI, R5         // h3 = hi(d0*r2)
+	ADDU	R19, R3        // h1 += a3 = lo(h4*s1)
+	SGTU	R19, R3, R19   // a3 = carry from h1 += lo(h4*s1)
+	ADDU	R19, R4        // h2 += that carry
+
+	// Eleventh multiply: d1 * r1.
+	MULU	R8, R15
+	MOVW	LO, R19        // a3 = lo(d1*r1)
+	MOVW	HI, R22        // t1 = hi(d1*r1)
+	ADDU	R24, R4        // h2 += at = lo(d0*r2)
+	SGTU	R24, R4, R24   // at = carry from h2 += lo(d0*r2)
+	ADDU	R24, R5        // h3 += that carry
+
+	// Twelfth multiply: d2 * r0.
+	MULU	R7, R20
+	MOVW	LO, R24        // at = lo(d2*r0)
+	MOVW	HI, R25        // t0 = hi(d2*r0)
+	ADDU	R19, R4        // h2 += a3 = lo(d1*r1)
+	ADDU	R22, R5        // h3 += t1 = hi(d1*r1)
+
+	// Thirteenth multiply: d3 * s3.
+	MULU	R13, R21
+	SGTU	R19, R4, R19   // a3 = carry from h2 += lo(d1*r1)
+	ADDU	R19, R5        // h3 += that carry
+	MOVW	LO, R19        // a3 = lo(d3*s3)
+	MOVW	HI, R22        // t1 = hi(d3*s3)
+	ADDU	R24, R4        // h2 += at = lo(d2*r0)
+	ADDU	R25, R5        // h3 += t0 = hi(d2*r0)
+
+	// Fourteenth multiply: h4 * s2. h4 ≤ 5, s2 < 2^30 → fits LO.
+	MULU	R12, R6
+	SGTU	R24, R4, R24   // at = carry from h2 += lo(d2*r0)
+	ADDU	R24, R5        // h3 += that carry
+	MOVW	LO, R24        // at = lo(h4*s2)
+	ADDU	R19, R4        // h2 += a3 = lo(d3*s3)
+	ADDU	R22, R5        // h3 += t1 = hi(d3*s3)
+
+	// Fifteenth multiply: d0 * r3.
+	MULU	R10, R14
+	SGTU	R19, R4, R19   // a3 = carry from h2 += lo(d3*s3)
+	ADDU	R19, R5        // h3 += that carry
+	MOVW	LO, R19        // a3 = lo(d0*r3)
+	MOVW	HI, R22        // t1 = hi(d0*r3)
+	ADDU	R24, R4        // h2 += at = lo(h4*s2)
+	SGTU	R24, R4, R24   // at = carry from h2 += lo(h4*s2)
+	ADDU	R24, R5        // h3 += that carry
+
+	// Sixteenth multiply: d1 * r2.
+	MULU	R9, R15
+	MOVW	LO, R24        // at = lo(d1*r2)
+	MOVW	HI, R25        // t0 = hi(d1*r2)
+	ADDU	R19, R5        // h3 += a3 = lo(d0*r3)
+	SGTU	R19, R5, R19   // a3 = carry from h3 += lo(d0*r3)
+	ADDU	R19, R22       // t1 += that carry
+
+	// Seventeenth multiply: d3 * r0.
+	MULU	R7, R21
+	MOVW	LO, R19        // a3 = lo(d3*r0)
+	MOVW	HI, R21        // d3 = hi(d3*r0) -- d3 dead, reused
+	ADDU	R24, R5        // h3 += at = lo(d1*r2)
+	ADDU	R25, R22       // t1 += t0 = hi(d1*r2)
+
+	// Eighteenth multiply: d2 * r1.
+	MULU	R8, R20
+	SGTU	R24, R5, R24   // at = carry from h3 += lo(d1*r2)
+	ADDU	R24, R22       // t1 += that carry
+	MOVW	LO, R24        // at = lo(d2*r1)
+	MOVW	HI, R25        // t0 = hi(d2*r1)
+	ADDU	R19, R5        // h3 += a3 = lo(d3*r0)
+	ADDU	R21, R22       // t1 += hi(d3*r0)
+
+	// Nineteenth multiply: h4 * s3. h4 ≤ 5, s3 < 2^30 → fits LO.
+	MULU	R13, R6
+	SGTU	R19, R5, R19   // a3 = carry from h3 += lo(d3*r0)
+	ADDU	R19, R22       // t1 += that carry
+	MOVW	LO, R19        // a3 = lo(h4*s3)
+	ADDU	R24, R5        // h3 += at = lo(d2*r1)
+	ADDU	R25, R22       // t1 += t0 = hi(d2*r1)
+
+	// Twentieth multiply: h4 * r0. After this h4 will be replaced
+	// with lo(h4*r0) plus the accumulated t1 carry chain.
+	MULU	R7, R6
+	SGTU	R24, R5, R24   // at = carry from h3 += lo(d2*r1)
+	ADDU	R24, R22       // t1 += that carry
+	MOVW	LO, R6         // h4 = lo(h4*r0)
+	ADDU	R19, R5        // h3 += a3 = lo(h4*s3)
+	SGTU	R19, R5, R19   // a3 = carry from h3 += lo(h4*s3)
+	ADDU	R19, R22       // t1 += that carry
+	ADDU	R22, R6        // h4 += t1
+
+	// Loop control. Upstream re-arms padbit=1 here; for our wrapper
+	// padbit only ever changes when blocks=1 (the final partial), so
+	// we don't need the re-arm.
+	ADDU	$16, R17
+	SUBU	$1, R18
+	BNE	R18, block_loop
+
+	// Store h back into state.
+	MOVW	R2, 0(R16)
+	MOVW	R3, 4(R16)
+	MOVW	R4, 8(R16)
+	MOVW	R5, 12(R16)
+	MOVW	R6, 16(R16)
+
+done:
+	RET

--- a/tsasm/mips32/poly1305/poly1305_mips_le.s
+++ b/tsasm/mips32/poly1305/poly1305_mips_le.s
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mipsle
+
+#include "textflag.h"
+
+// poly1305Update(state *macState, msg unsafe.Pointer, blocks uintptr, padbit uintptr)
+//
+// Hand-translated from openssl/Linux poly1305-mips.pl (Andy Polyakov,
+// dual-licensed BSD-3-Clause / OpenSSL); the 32-bit non-MADDU code
+// path. 5x32 saturated h, 4x32 saturated r, plus precomputed
+// s_i = r_i + (r_i >> 2) for i in 1..3 to fold the 2^130 ≡ 5
+// reduction into the multiplication.
+//
+// 20 partial products per 16-byte block. Each is MULTU + MFLO +
+// MFHI + manual ADDU/SLTU(SGTU) carry chain -- no MADDU into the
+// HI/LO accumulator. The earlier 5x26 attempt that DID use MADDU
+// gave occasional wrong tags (~7%) on real Cavium Octeon II and
+// Ingenic JZ4780 silicon; this layout avoids the multi-MADDU
+// chain entirely.
+//
+// LE variant: input is loaded with plain MOVW (LWU equivalent on
+// 32-bit MIPS); on a little-endian host that already gives an LE
+// u32. The BE variant in poly1305_mips_be.s adds a WSBH+ROTR16
+// pair after each input load.
+//
+// Register usage (Plan 9 names, MIPS o32 ABI labels in parens):
+//
+//   R16 (s0)  ctx ptr        R7  (a3)  r0
+//   R17 (s1)  msg ptr        R8  (t0)  r1
+//   R18 (s2)  blocks count   R9  (t1)  r2
+//   R19 (s3)  padbit         R10 (t2)  r3
+//                            R11 (t3)  s1
+//   R2  (v0)  h0             R12 (t4)  s2
+//   R3  (v1)  h1             R13 (t5)  s3
+//   R4  (a0)  h2
+//   R5  (a1)  h3             R14, R15, R20, R21  d0..d3
+//   R6  (a2)  h4             R24..R19  scratch (at, t0, t1, a3)
+//
+// R22 (REGCTXT) and R23 (REGTMP) are left alone.
+TEXT ·poly1305Update(SB), NOSPLIT, $0-16
+	MOVW	state+0(FP), R16
+	MOVW	msg+4(FP), R17
+	MOVW	blocks+8(FP), R18
+	MOVW	padbit+12(FP), R19
+
+	BEQ	R18, done
+
+	// Load h[0..4] and r[0..3] and s[1..3] from state.
+	MOVW	0(R16), R2     // h0
+	MOVW	4(R16), R3     // h1
+	MOVW	8(R16), R4     // h2
+	MOVW	12(R16), R5    // h3
+	MOVW	16(R16), R6    // h4
+	MOVW	20(R16), R7    // r0
+	MOVW	24(R16), R8    // r1
+	MOVW	28(R16), R9    // r2
+	MOVW	32(R16), R10   // r3
+	MOVW	36(R16), R11   // s1
+	MOVW	40(R16), R12   // s2
+	MOVW	44(R16), R13   // s3
+
+block_loop:
+	// padbit lives in R19 only briefly each block (ADDU R19, R6
+	// below); we then reuse R19 as the `a3` scratch slot to fit
+	// inside the no-R26/R27 register budget. Reload from the args
+	// frame at the top of every block.
+	MOVW	padbit+12(FP), R19
+
+	// Read 16 bytes of input as 4 LE u32 words. On mipsle, MOVW
+	// gives the LE value directly.
+	MOVW	0(R17), R14    // d0
+	MOVW	4(R17), R15    // d1
+	MOVW	8(R17), R20    // d2
+	MOVW	12(R17), R21   // d3
+
+	// Modulo-scheduled fold of h4's high bits back into h0 via *5
+	// before the input add.
+	SRL	$2, R6, R25    // t0 = h4 >> 2
+	AND	$3, R6, R6     // h4 &= 3
+	SLL	$2, R25, R24   // at = t0 * 4
+
+	// d0 = (in0 + h0) + (h4>>2)*5 (residue).
+	ADDU	R2, R14        // d0 += h0   (R14 = R2 + R14)
+	ADDU	R24, R25       // t0 += at  → t0 = (h4>>2)*5
+	SGTU	R2, R14, R2    // h0 = carry from d0 += h0_old (= h0_old > d0)
+	ADDU	R25, R14       // d0 += residue
+	SGTU	R25, R14, R24  // at = carry from d0 += residue
+
+	// d1 = in1 + h1 + carry-chain.
+	ADDU	R3, R15        // d1 += h1
+	ADDU	R24, R2        // h0 += at (combine carries)
+	SGTU	R3, R15, R3    // h1 = carry from d1 += h1
+	ADDU	R2, R15        // d1 += h0 (combined carry)
+	SGTU	R2, R15, R2    // h0 = carry from d1 += h0
+
+	// d2 = in2 + h2 + carry.
+	ADDU	R4, R20        // d2 += h2
+	ADDU	R2, R3         // h1 += h0 (combine)
+	SGTU	R4, R20, R4    // h2 = carry from d2 += h2
+	ADDU	R3, R20        // d2 += h1
+	SGTU	R3, R20, R3    // h1 = carry from d2 += h1
+
+	// d3 = in3 + h3 + carry.
+	ADDU	R5, R21        // d3 += h3
+	ADDU	R3, R4         // h2 += h1
+	SGTU	R5, R21, R5    // h3 = carry from d3 += h3
+	ADDU	R4, R21        // d3 += h2
+
+	// First multiply: d0 * r0.
+	MULU	R7, R14
+	SGTU	R4, R21, R4    // h2 = carry from d3 += h2 (final)
+	ADDU	R4, R5         // h3 += h2 (final carry into h3)
+	MOVW	LO, R2         // h0 = lo(d0*r0)
+	MOVW	HI, R3         // h1 = hi(d0*r0)
+
+	// Second multiply: d1 * s3.
+	MULU	R13, R15
+	ADDU	R19, R6        // h4 += padbit
+	ADDU	R5, R6         // h4 += h3 (final carry)
+	MOVW	LO, R24        // at = lo(d1*s3)
+	MOVW	HI, R25        // t0 = hi(d1*s3)
+
+	// Third multiply: d2 * s2.
+	MULU	R12, R20
+	MOVW	LO, R19        // a3 = lo(d2*s2)
+	MOVW	HI, R22        // t1 = hi(d2*s2)
+	ADDU	R24, R2        // h0 += at = lo(d1*s3)
+	ADDU	R25, R3        // h1 += t0 = hi(d1*s3)
+
+	// Fourth multiply: d3 * s1.
+	MULU	R11, R21
+	SGTU	R24, R2, R24   // at = carry from h0 += lo(d1*s3)
+	ADDU	R24, R3        // h1 += that carry
+	MOVW	LO, R24        // at = lo(d3*s1)
+	MOVW	HI, R25        // t0 = hi(d3*s1)
+	ADDU	R19, R2        // h0 += a3 = lo(d2*s2)
+	ADDU	R22, R3        // h1 += t1 = hi(d2*s2)
+
+	// Fifth multiply: d0 * r1.
+	MULU	R8, R14
+	SGTU	R19, R2, R19   // a3 = carry from h0 += lo(d2*s2)
+	ADDU	R19, R3        // h1 += that carry
+	MOVW	LO, R19        // a3 = lo(d0*r1)
+	MOVW	HI, R4         // h2 = hi(d0*r1)
+	ADDU	R24, R2        // h0 += at = lo(d3*s1)
+	ADDU	R25, R3        // h1 += t0 = hi(d3*s1)
+
+	// Sixth multiply: d1 * r0.
+	MULU	R7, R15
+	SGTU	R24, R2, R24   // at = carry from h0 += lo(d3*s1)
+	ADDU	R24, R3        // h1 += that carry
+	MOVW	LO, R24        // at = lo(d1*r0)
+	MOVW	HI, R25        // t0 = hi(d1*r0)
+	ADDU	R19, R3        // h1 += a3 = lo(d0*r1)
+	SGTU	R19, R3, R19   // a3 = carry from h1 += lo(d0*r1)
+
+	// Seventh multiply: d2 * s3.
+	MULU	R13, R20
+	ADDU	R19, R4        // h2 += that carry
+	MOVW	LO, R19        // a3 = lo(d2*s3)
+	MOVW	HI, R22        // t1 = hi(d2*s3)
+	ADDU	R24, R3        // h1 += at = lo(d1*r0)
+	ADDU	R25, R4        // h2 += t0 = hi(d1*r0)
+
+	// Eighth multiply: d3 * s2.
+	MULU	R12, R21
+	SGTU	R24, R3, R24   // at = carry from h1 += lo(d1*r0)
+	ADDU	R24, R4        // h2 += that carry
+	MOVW	LO, R24        // at = lo(d3*s2)
+	MOVW	HI, R25        // t0 = hi(d3*s2)
+	ADDU	R19, R3        // h1 += a3 = lo(d2*s3)
+	ADDU	R22, R4        // h2 += t1 = hi(d2*s3)
+
+	// Ninth multiply: h4 * s1. Bounded: h4 ≤ 5, s1 < 2^30, so
+	// product fits in LO and we ignore HI.
+	MULU	R11, R6
+	SGTU	R19, R3, R19   // a3 = carry from h1 += lo(d2*s3)
+	ADDU	R19, R4        // h2 += that carry
+	MOVW	LO, R19        // a3 = lo(h4*s1)
+	ADDU	R24, R3        // h1 += at = lo(d3*s2)
+	ADDU	R25, R4        // h2 += t0 = hi(d3*s2)
+
+	// Tenth multiply: d0 * r2.
+	MULU	R9, R14
+	SGTU	R24, R3, R24   // at = carry from h1 += lo(d3*s2)
+	ADDU	R24, R4        // h2 += that carry
+	MOVW	LO, R24        // at = lo(d0*r2)
+	MOVW	HI, R5         // h3 = hi(d0*r2)
+	ADDU	R19, R3        // h1 += a3 = lo(h4*s1)
+	SGTU	R19, R3, R19   // a3 = carry from h1 += lo(h4*s1)
+	ADDU	R19, R4        // h2 += that carry
+
+	// Eleventh multiply: d1 * r1.
+	MULU	R8, R15
+	MOVW	LO, R19        // a3 = lo(d1*r1)
+	MOVW	HI, R22        // t1 = hi(d1*r1)
+	ADDU	R24, R4        // h2 += at = lo(d0*r2)
+	SGTU	R24, R4, R24   // at = carry from h2 += lo(d0*r2)
+	ADDU	R24, R5        // h3 += that carry
+
+	// Twelfth multiply: d2 * r0.
+	MULU	R7, R20
+	MOVW	LO, R24        // at = lo(d2*r0)
+	MOVW	HI, R25        // t0 = hi(d2*r0)
+	ADDU	R19, R4        // h2 += a3 = lo(d1*r1)
+	ADDU	R22, R5        // h3 += t1 = hi(d1*r1)
+
+	// Thirteenth multiply: d3 * s3.
+	MULU	R13, R21
+	SGTU	R19, R4, R19   // a3 = carry from h2 += lo(d1*r1)
+	ADDU	R19, R5        // h3 += that carry
+	MOVW	LO, R19        // a3 = lo(d3*s3)
+	MOVW	HI, R22        // t1 = hi(d3*s3)
+	ADDU	R24, R4        // h2 += at = lo(d2*r0)
+	ADDU	R25, R5        // h3 += t0 = hi(d2*r0)
+
+	// Fourteenth multiply: h4 * s2. h4 ≤ 5, s2 < 2^30 → fits LO.
+	MULU	R12, R6
+	SGTU	R24, R4, R24   // at = carry from h2 += lo(d2*r0)
+	ADDU	R24, R5        // h3 += that carry
+	MOVW	LO, R24        // at = lo(h4*s2)
+	ADDU	R19, R4        // h2 += a3 = lo(d3*s3)
+	ADDU	R22, R5        // h3 += t1 = hi(d3*s3)
+
+	// Fifteenth multiply: d0 * r3.
+	MULU	R10, R14
+	SGTU	R19, R4, R19   // a3 = carry from h2 += lo(d3*s3)
+	ADDU	R19, R5        // h3 += that carry
+	MOVW	LO, R19        // a3 = lo(d0*r3)
+	MOVW	HI, R22        // t1 = hi(d0*r3)
+	ADDU	R24, R4        // h2 += at = lo(h4*s2)
+	SGTU	R24, R4, R24   // at = carry from h2 += lo(h4*s2)
+	ADDU	R24, R5        // h3 += that carry
+
+	// Sixteenth multiply: d1 * r2.
+	MULU	R9, R15
+	MOVW	LO, R24        // at = lo(d1*r2)
+	MOVW	HI, R25        // t0 = hi(d1*r2)
+	ADDU	R19, R5        // h3 += a3 = lo(d0*r3)
+	SGTU	R19, R5, R19   // a3 = carry from h3 += lo(d0*r3)
+	ADDU	R19, R22       // t1 += that carry
+
+	// Seventeenth multiply: d3 * r0.
+	MULU	R7, R21
+	MOVW	LO, R19        // a3 = lo(d3*r0)
+	MOVW	HI, R21        // d3 = hi(d3*r0) -- d3 dead, reused
+	ADDU	R24, R5        // h3 += at = lo(d1*r2)
+	ADDU	R25, R22       // t1 += t0 = hi(d1*r2)
+
+	// Eighteenth multiply: d2 * r1.
+	MULU	R8, R20
+	SGTU	R24, R5, R24   // at = carry from h3 += lo(d1*r2)
+	ADDU	R24, R22       // t1 += that carry
+	MOVW	LO, R24        // at = lo(d2*r1)
+	MOVW	HI, R25        // t0 = hi(d2*r1)
+	ADDU	R19, R5        // h3 += a3 = lo(d3*r0)
+	ADDU	R21, R22       // t1 += hi(d3*r0)
+
+	// Nineteenth multiply: h4 * s3. h4 ≤ 5, s3 < 2^30 → fits LO.
+	MULU	R13, R6
+	SGTU	R19, R5, R19   // a3 = carry from h3 += lo(d3*r0)
+	ADDU	R19, R22       // t1 += that carry
+	MOVW	LO, R19        // a3 = lo(h4*s3)
+	ADDU	R24, R5        // h3 += at = lo(d2*r1)
+	ADDU	R25, R22       // t1 += t0 = hi(d2*r1)
+
+	// Twentieth multiply: h4 * r0. After this h4 will be replaced
+	// with lo(h4*r0) plus the accumulated t1 carry chain.
+	MULU	R7, R6
+	SGTU	R24, R5, R24   // at = carry from h3 += lo(d2*r1)
+	ADDU	R24, R22       // t1 += that carry
+	MOVW	LO, R6         // h4 = lo(h4*r0)
+	ADDU	R19, R5        // h3 += a3 = lo(h4*s3)
+	SGTU	R19, R5, R19   // a3 = carry from h3 += lo(h4*s3)
+	ADDU	R19, R22       // t1 += that carry
+	ADDU	R22, R6        // h4 += t1
+
+	// Loop control. Upstream re-arms padbit=1 here; for our wrapper
+	// padbit only ever changes when blocks=1 (the final partial), so
+	// we don't need the re-arm.
+	ADDU	$16, R17
+	SUBU	$1, R18
+	BNE	R18, block_loop
+
+	// Store h back into state.
+	MOVW	R2, 0(R16)
+	MOVW	R3, 4(R16)
+	MOVW	R4, 8(R16)
+	MOVW	R5, 12(R16)
+	MOVW	R6, 16(R16)
+
+done:
+	RET

--- a/tsasm/mips32/poly1305/poly1305_test.go
+++ b/tsasm/mips32/poly1305/poly1305_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips || mipsle
+
+package poly1305
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	xpoly1305 "golang.org/x/crypto/poly1305"
+)
+
+func TestRFC8439Vector(t *testing.T) {
+	keyHex := "85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b"
+	src := "Cryptographic Forum Research Group"
+	msg := make([]byte, len(src))
+	copy(msg, src)
+	wantHex := "a8061dc1305136c6c22b8baf0c0127a9"
+
+	var key [32]byte
+	mustHex(t, key[:], keyHex)
+	wantTag := mustHexBytes(t, wantHex)
+
+	var got [16]byte
+	Sum(&got, msg, &key)
+	if !bytes.Equal(got[:], wantTag) {
+		t.Errorf("Sum mismatch:\n got %x\nwant %x", got, wantTag)
+	}
+}
+
+func TestAgainstReference(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+
+	for _, n := range []int{0, 1, 7, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 1023, 1024, 1436, 4096} {
+		t.Run(fmt.Sprintf("len=%d", n), func(t *testing.T) {
+			msg := make([]byte, n)
+			rand.Read(msg)
+
+			var got [16]byte
+			Sum(&got, msg, &key)
+
+			var want [16]byte
+			xpoly1305.Sum(&want, msg, &key)
+
+			if !bytes.Equal(got[:], want[:]) {
+				t.Errorf("mismatch (len=%d):\n got %x\nwant %x", n, got, want)
+			}
+		})
+	}
+}
+
+func TestIncrementalWrite(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+
+	full := make([]byte, 4096)
+	rand.Read(full)
+
+	var want [16]byte
+	xpoly1305.Sum(&want, full, &key)
+
+	for _, chunk := range []int{1, 7, 15, 16, 17, 64, 1024} {
+		t.Run(fmt.Sprintf("chunk=%d", chunk), func(t *testing.T) {
+			var mac MAC
+			mac.Init(&key)
+			for i := 0; i < len(full); i += chunk {
+				j := min(i+chunk, len(full))
+				mac.Write(full[i:j])
+			}
+			var got [16]byte
+			mac.Sum(&got)
+			if !bytes.Equal(got[:], want[:]) {
+				t.Errorf("chunk=%d mismatch", chunk)
+			}
+		})
+	}
+}
+
+func mustHex(t *testing.T, dst []byte, s string) {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) != len(dst) {
+		t.Fatalf("hex length %d, want %d", len(b), len(dst))
+	}
+	copy(dst, b)
+}
+
+func mustHexBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// BenchmarkSum measures asm vs pure-Go Poly1305 throughput at the
+// sizes that show up on the WireGuard data path.
+func BenchmarkSum(b *testing.B) {
+	for _, size := range []int{64, 1436, 4096, 16384} {
+		var key [32]byte
+		rand.Read(key[:])
+		msg := make([]byte, size)
+		rand.Read(msg)
+		b.Run(fmt.Sprintf("%d/asm", size), func(b *testing.B) {
+			var tag [16]byte
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				Sum(&tag, msg, &key)
+			}
+		})
+		b.Run(fmt.Sprintf("%d/xcrypto", size), func(b *testing.B) {
+			var tag [16]byte
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				xpoly1305.Sum(&tag, msg, &key)
+			}
+		})
+	}
+}

--- a/tsasm/mips64/chacha20/chacha20_mips64.go
+++ b/tsasm/mips64/chacha20/chacha20_mips64.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+// Package chacha20 implements the ChaCha20 stream cipher with a
+// scalar mips64r2 inner loop. It only builds on big-endian
+// GOARCH=mips64; other architectures should use
+// golang.org/x/crypto/chacha20. (The byte-swap path here assumes
+// big-endian memory order; mips64le would need a separate asm.)
+package chacha20
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+const (
+	KeySize   = 32
+	NonceSize = 12
+	BlockSize = 64
+)
+
+// ChaCha20 sigma constants ("expand 32-byte k" in little-endian u32
+// chunks).
+const (
+	sigma0 uint32 = 0x61707865
+	sigma1 uint32 = 0x3320646e
+	sigma2 uint32 = 0x79622d32
+	sigma3 uint32 = 0x6b206574
+)
+
+// chacha20BlocksASM XORs `blocks` 64-byte blocks of ChaCha20
+// keystream into `in`, writing to `out`. state[0..15] is the initial
+// 16 u32 ChaCha20 state in machine-endian form (sigma | key |
+// counter | nonce). On return, state[12] is incremented by `blocks`.
+//
+//go:noescape
+func chacha20BlocksASM(out, in unsafe.Pointer, state *[16]uint32, blocks uintptr)
+
+// XORKeyStream XORs a ChaCha20 keystream into in, writing to out, using
+// the given 32-byte key, 12-byte IETF nonce, and starting 32-bit block
+// counter. out and in must have the same length and may overlap exactly
+// or not at all. It returns the next block counter
+// (counter + ceil(len/64)).
+//
+// Both `out` and `in` should be 4-byte aligned. Slices from make()
+// are; slices derived from string literals (which may live in
+// rodata) are not. The asm reads/writes 32-bit words; on Octeon the
+// kernel silently fixes up unaligned traps (slow but correct), but
+// stricter MIPS environments (qemu-user, certain bare-metal kernels)
+// raise SIGBUS. WireGuard's data path uses pooled make()-allocated
+// buffers and is therefore safe.
+func XORKeyStream(out, in []byte, key *[KeySize]byte, nonce *[NonceSize]byte, counter uint32) uint32 {
+	if len(out) < len(in) {
+		panic("chacha20: output buffer shorter than input")
+	}
+	if len(in) == 0 {
+		return counter
+	}
+
+	var state [16]uint32
+	state[0] = sigma0
+	state[1] = sigma1
+	state[2] = sigma2
+	state[3] = sigma3
+	for i := range 8 {
+		state[4+i] = binary.LittleEndian.Uint32(key[i*4:])
+	}
+	state[12] = counter
+	state[13] = binary.LittleEndian.Uint32(nonce[0:])
+	state[14] = binary.LittleEndian.Uint32(nonce[4:])
+	state[15] = binary.LittleEndian.Uint32(nonce[8:])
+
+	full := len(in) &^ 63 // largest multiple of 64
+	if full > 0 {
+		chacha20BlocksASM(
+			unsafe.Pointer(&out[0]),
+			unsafe.Pointer(&in[0]),
+			&state,
+			uintptr(full>>6),
+		)
+	}
+	if rem := len(in) - full; rem > 0 {
+		// Handle the final partial block by routing it through a
+		// 64-byte staging buffer so the asm always sees a full block.
+		var inBuf, outBuf [64]byte
+		copy(inBuf[:], in[full:])
+		chacha20BlocksASM(
+			unsafe.Pointer(&outBuf[0]),
+			unsafe.Pointer(&inBuf[0]),
+			&state,
+			1,
+		)
+		copy(out[full:], outBuf[:rem])
+	}
+
+	return counter + uint32((len(in)+63)>>6)
+}

--- a/tsasm/mips64/chacha20/chacha20_mips64.s
+++ b/tsasm/mips64/chacha20/chacha20_mips64.s
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+#include "textflag.h"
+
+// chacha20BlocksASM(out, in unsafe.Pointer, state *[16]uint32, blocks uintptr)
+//
+// Hand-written scalar mips64r2 ChaCha20. All 16 u32 state words live
+// in registers (R2..R17) for the duration of each block. The four
+// rotate counts (16, 12, 8, 7) are folded to right-rotates (16, 20,
+// 24, 25) using the MIPS r2 ROTR instruction. Each output word is
+// byte-swapped on store with WSBH+ROTR16 so the keystream comes out
+// in little-endian order regardless of host endianness; the same
+// dance on the load side lets us XOR plaintext into the state
+// register before the swap-and-store.
+//
+// Register usage:
+//   R2..R17  = x[0..15] working state.
+//   R18      = out pointer.
+//   R19      = in pointer.
+//   R20      = state pointer.
+//   R21      = remaining-blocks counter.
+//   R22      = scratch.
+//   R24      = round-pair counter (10 -> 0).
+TEXT ·chacha20BlocksASM(SB), NOSPLIT|NOFRAME, $0-32
+	MOVV	out+0(FP), R18
+	MOVV	in+8(FP), R19
+	MOVV	state+16(FP), R20
+	MOVV	blocks+24(FP), R21
+
+	BEQ	R21, done
+
+block_loop:
+	// Load 16-word state into x[0..15] (R2..R17).
+	MOVW	0(R20), R2
+	MOVW	4(R20), R3
+	MOVW	8(R20), R4
+	MOVW	12(R20), R5
+	MOVW	16(R20), R6
+	MOVW	20(R20), R7
+	MOVW	24(R20), R8
+	MOVW	28(R20), R9
+	MOVW	32(R20), R10
+	MOVW	36(R20), R11
+	MOVW	40(R20), R12
+	MOVW	44(R20), R13
+	MOVW	48(R20), R14
+	MOVW	52(R20), R15
+	MOVW	56(R20), R16
+	MOVW	60(R20), R17
+
+	MOVV	$10, R24
+
+round_loop:
+	// Column round.
+	// QR(0, 4, 8, 12)  -> R2, R6, R10, R14
+	ADDU	R6, R2, R2
+	XOR	R2, R14, R14
+	ROTR	$16, R14, R14
+	ADDU	R14, R10, R10
+	XOR	R10, R6, R6
+	ROTR	$20, R6, R6
+	ADDU	R6, R2, R2
+	XOR	R2, R14, R14
+	ROTR	$24, R14, R14
+	ADDU	R14, R10, R10
+	XOR	R10, R6, R6
+	ROTR	$25, R6, R6
+
+	// QR(1, 5, 9, 13)  -> R3, R7, R11, R15
+	ADDU	R7, R3, R3
+	XOR	R3, R15, R15
+	ROTR	$16, R15, R15
+	ADDU	R15, R11, R11
+	XOR	R11, R7, R7
+	ROTR	$20, R7, R7
+	ADDU	R7, R3, R3
+	XOR	R3, R15, R15
+	ROTR	$24, R15, R15
+	ADDU	R15, R11, R11
+	XOR	R11, R7, R7
+	ROTR	$25, R7, R7
+
+	// QR(2, 6, 10, 14) -> R4, R8, R12, R16
+	ADDU	R8, R4, R4
+	XOR	R4, R16, R16
+	ROTR	$16, R16, R16
+	ADDU	R16, R12, R12
+	XOR	R12, R8, R8
+	ROTR	$20, R8, R8
+	ADDU	R8, R4, R4
+	XOR	R4, R16, R16
+	ROTR	$24, R16, R16
+	ADDU	R16, R12, R12
+	XOR	R12, R8, R8
+	ROTR	$25, R8, R8
+
+	// QR(3, 7, 11, 15) -> R5, R9, R13, R17
+	ADDU	R9, R5, R5
+	XOR	R5, R17, R17
+	ROTR	$16, R17, R17
+	ADDU	R17, R13, R13
+	XOR	R13, R9, R9
+	ROTR	$20, R9, R9
+	ADDU	R9, R5, R5
+	XOR	R5, R17, R17
+	ROTR	$24, R17, R17
+	ADDU	R17, R13, R13
+	XOR	R13, R9, R9
+	ROTR	$25, R9, R9
+
+	// Diagonal round.
+	// QR(0, 5, 10, 15) -> R2, R7, R12, R17
+	ADDU	R7, R2, R2
+	XOR	R2, R17, R17
+	ROTR	$16, R17, R17
+	ADDU	R17, R12, R12
+	XOR	R12, R7, R7
+	ROTR	$20, R7, R7
+	ADDU	R7, R2, R2
+	XOR	R2, R17, R17
+	ROTR	$24, R17, R17
+	ADDU	R17, R12, R12
+	XOR	R12, R7, R7
+	ROTR	$25, R7, R7
+
+	// QR(1, 6, 11, 12) -> R3, R8, R13, R14
+	ADDU	R8, R3, R3
+	XOR	R3, R14, R14
+	ROTR	$16, R14, R14
+	ADDU	R14, R13, R13
+	XOR	R13, R8, R8
+	ROTR	$20, R8, R8
+	ADDU	R8, R3, R3
+	XOR	R3, R14, R14
+	ROTR	$24, R14, R14
+	ADDU	R14, R13, R13
+	XOR	R13, R8, R8
+	ROTR	$25, R8, R8
+
+	// QR(2, 7, 8, 13)  -> R4, R9, R10, R15
+	ADDU	R9, R4, R4
+	XOR	R4, R15, R15
+	ROTR	$16, R15, R15
+	ADDU	R15, R10, R10
+	XOR	R10, R9, R9
+	ROTR	$20, R9, R9
+	ADDU	R9, R4, R4
+	XOR	R4, R15, R15
+	ROTR	$24, R15, R15
+	ADDU	R15, R10, R10
+	XOR	R10, R9, R9
+	ROTR	$25, R9, R9
+
+	// QR(3, 4, 9, 14)  -> R5, R6, R11, R16
+	ADDU	R6, R5, R5
+	XOR	R5, R16, R16
+	ROTR	$16, R16, R16
+	ADDU	R16, R11, R11
+	XOR	R11, R6, R6
+	ROTR	$20, R6, R6
+	ADDU	R6, R5, R5
+	XOR	R5, R16, R16
+	ROTR	$24, R16, R16
+	ADDU	R16, R11, R11
+	XOR	R11, R6, R6
+	ROTR	$25, R6, R6
+
+	SUBVU	$1, R24
+	BNE	R24, round_loop
+
+	// Add the original state back into x[0..15]. We just reload
+	// state[i] from memory through R22; the in-memory copy is
+	// untouched until the counter bump at the end of this block.
+	MOVW	0(R20), R22
+	ADDU	R22, R2, R2
+	MOVW	4(R20), R22
+	ADDU	R22, R3, R3
+	MOVW	8(R20), R22
+	ADDU	R22, R4, R4
+	MOVW	12(R20), R22
+	ADDU	R22, R5, R5
+	MOVW	16(R20), R22
+	ADDU	R22, R6, R6
+	MOVW	20(R20), R22
+	ADDU	R22, R7, R7
+	MOVW	24(R20), R22
+	ADDU	R22, R8, R8
+	MOVW	28(R20), R22
+	ADDU	R22, R9, R9
+	MOVW	32(R20), R22
+	ADDU	R22, R10, R10
+	MOVW	36(R20), R22
+	ADDU	R22, R11, R11
+	MOVW	40(R20), R22
+	ADDU	R22, R12, R12
+	MOVW	44(R20), R22
+	ADDU	R22, R13, R13
+	MOVW	48(R20), R22
+	ADDU	R22, R14, R14
+	MOVW	52(R20), R22
+	ADDU	R22, R15, R15
+	MOVW	56(R20), R22
+	ADDU	R22, R16, R16
+	MOVW	60(R20), R22
+	ADDU	R22, R17, R17
+
+	// XOR with input and store.
+	// in_le = byteswap(LW(in+4i))
+	// out_le = x[i] XOR in_le
+	// SW(out+4i, byteswap(out_le))
+	//
+	// On big-endian MIPS, LW reads bytes [b0,b1,b2,b3] as the BE
+	// integer 0xb0b1b2b3; we want 0xb3b2b1b0 (the LE
+	// interpretation). WSBH+ROTR16 effects a full 32-bit byte swap.
+	// On little-endian MIPS the byte swaps are wasted work but
+	// correct -- the asm is shared between both targets.
+	MOVW	0(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R2, R2
+	WSBH	R2, R2
+	ROTR	$16, R2, R2
+	MOVW	R2, 0(R18)
+
+	MOVW	4(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R3, R3
+	WSBH	R3, R3
+	ROTR	$16, R3, R3
+	MOVW	R3, 4(R18)
+
+	MOVW	8(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R4, R4
+	WSBH	R4, R4
+	ROTR	$16, R4, R4
+	MOVW	R4, 8(R18)
+
+	MOVW	12(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R5, R5
+	WSBH	R5, R5
+	ROTR	$16, R5, R5
+	MOVW	R5, 12(R18)
+
+	MOVW	16(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R6, R6
+	WSBH	R6, R6
+	ROTR	$16, R6, R6
+	MOVW	R6, 16(R18)
+
+	MOVW	20(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R7, R7
+	WSBH	R7, R7
+	ROTR	$16, R7, R7
+	MOVW	R7, 20(R18)
+
+	MOVW	24(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R8, R8
+	WSBH	R8, R8
+	ROTR	$16, R8, R8
+	MOVW	R8, 24(R18)
+
+	MOVW	28(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R9, R9
+	WSBH	R9, R9
+	ROTR	$16, R9, R9
+	MOVW	R9, 28(R18)
+
+	MOVW	32(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R10, R10
+	WSBH	R10, R10
+	ROTR	$16, R10, R10
+	MOVW	R10, 32(R18)
+
+	MOVW	36(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R11, R11
+	WSBH	R11, R11
+	ROTR	$16, R11, R11
+	MOVW	R11, 36(R18)
+
+	MOVW	40(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R12, R12
+	WSBH	R12, R12
+	ROTR	$16, R12, R12
+	MOVW	R12, 40(R18)
+
+	MOVW	44(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R13, R13
+	WSBH	R13, R13
+	ROTR	$16, R13, R13
+	MOVW	R13, 44(R18)
+
+	MOVW	48(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R14, R14
+	WSBH	R14, R14
+	ROTR	$16, R14, R14
+	MOVW	R14, 48(R18)
+
+	MOVW	52(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R15, R15
+	WSBH	R15, R15
+	ROTR	$16, R15, R15
+	MOVW	R15, 52(R18)
+
+	MOVW	56(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R16, R16
+	WSBH	R16, R16
+	ROTR	$16, R16, R16
+	MOVW	R16, 56(R18)
+
+	MOVW	60(R19), R22
+	WSBH	R22, R22
+	ROTR	$16, R22, R22
+	XOR	R22, R17, R17
+	WSBH	R17, R17
+	ROTR	$16, R17, R17
+	MOVW	R17, 60(R18)
+
+	// Bump the in-memory counter by one.
+	MOVW	48(R20), R22
+	ADDU	$1, R22, R22
+	MOVW	R22, 48(R20)
+
+	// Advance pointers; loop while blocks remain.
+	ADDV	$64, R18
+	ADDV	$64, R19
+	SUBVU	$1, R21
+	BNE	R21, block_loop
+
+done:
+	RET

--- a/tsasm/mips64/chacha20/chacha20_test.go
+++ b/tsasm/mips64/chacha20/chacha20_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+package chacha20
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	xchacha "golang.org/x/crypto/chacha20"
+)
+
+// RFC 8439 §2.4.2 test vector.
+func TestRFC8439Vector(t *testing.T) {
+	keyHex := "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+	nonceHex := "000000000000004a00000000"
+	const counter = 1
+	// Use make() not a string literal so the byte slice is 4-byte
+	// aligned; the asm requires it.
+	src := "Ladies and Gentlemen of the class of '99: " +
+		"If I could offer you only one tip for the future, sunscreen would be it."
+	plaintext := make([]byte, len(src))
+	copy(plaintext, src)
+	wantHex := "" +
+		"6e2e359a2568f98041ba0728dd0d6981" +
+		"e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab" +
+		"8f593dabcd62b3571639d624e65152ab8f530c359f0861d8" +
+		"07ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806" +
+		"818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42" +
+		"874d"
+
+	var key [32]byte
+	mustHex(t, key[:], keyHex)
+	var nonce [12]byte
+	mustHex(t, nonce[:], nonceHex)
+	want := mustHexBytes(t, wantHex)
+
+	out := make([]byte, len(plaintext))
+	XORKeyStream(out, plaintext, &key, &nonce, counter)
+
+	if !bytes.Equal(out, want) {
+		t.Fatalf("RFC 8439 vector mismatch:\n got %x\nwant %x", out, want)
+	}
+}
+
+// Cross-check against golang.org/x/crypto/chacha20 for randomized inputs
+// across a range of lengths that exercise full-block, partial-block,
+// and zero-length paths.
+func TestAgainstReference(t *testing.T) {
+	var key [32]byte
+	var nonce [12]byte
+	rand.Read(key[:])
+	rand.Read(nonce[:])
+
+	lengths := []int{0, 1, 16, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 511, 512, 1024, 1500, 4096, 8192}
+	for _, n := range lengths {
+		t.Run(fmt.Sprintf("len=%d", n), func(t *testing.T) {
+			in := make([]byte, n)
+			rand.Read(in)
+			got := make([]byte, n)
+			want := make([]byte, n)
+
+			XORKeyStream(got, in, &key, &nonce, 0)
+
+			c, err := xchacha.NewUnauthenticatedCipher(key[:], nonce[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.XORKeyStream(want, in)
+
+			if !bytes.Equal(got, want) {
+				t.Errorf("mismatch (n=%d):\n got %x\nwant %x", n, got, want)
+			}
+		})
+	}
+}
+
+// Counter is incremented correctly across multi-block calls.
+func TestCounterAdvance(t *testing.T) {
+	var key [32]byte
+	var nonce [12]byte
+	rand.Read(key[:])
+	rand.Read(nonce[:])
+
+	in := make([]byte, 192) // 3 full blocks
+	out := make([]byte, len(in))
+	got := XORKeyStream(out, in, &key, &nonce, 7)
+	if got != 7+3 {
+		t.Errorf("counter = %d, want %d", got, 7+3)
+	}
+
+	// One partial block also advances by 1.
+	got = XORKeyStream(out[:5], in[:5], &key, &nonce, 100)
+	if got != 100+1 {
+		t.Errorf("counter (partial) = %d, want %d", got, 100+1)
+	}
+}
+
+func mustHex(t *testing.T, dst []byte, s string) {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) != len(dst) {
+		t.Fatalf("hex length %d, want %d", len(b), len(dst))
+	}
+	copy(dst, b)
+}
+
+func mustHexBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// BenchmarkXORKeyStream measures pure ChaCha20 throughput at a typical
+// WireGuard data-packet size (1420 bytes).
+func BenchmarkXORKeyStream(b *testing.B) {
+	for _, size := range []int{64, 256, 1420, 8192} {
+		var key [32]byte
+		var nonce [12]byte
+		in := make([]byte, size)
+		out := make([]byte, size)
+		b.Run(fmt.Sprintf("%d/asm", size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				XORKeyStream(out, in, &key, &nonce, 0)
+			}
+		})
+		b.Run(fmt.Sprintf("%d/xcrypto", size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				c, _ := xchacha.NewUnauthenticatedCipher(key[:], nonce[:])
+				c.XORKeyStream(out, in)
+			}
+		})
+	}
+}

--- a/tsasm/mips64/chacha20poly1305/aead_compat_test.go
+++ b/tsasm/mips64/chacha20poly1305/aead_compat_test.go
@@ -1,0 +1,251 @@
+//go:build mips64
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+// Adapted from device/aead_compat_test.go: same vectors and
+// agreement-with-reference checks, but the AEAD-under-test slot is
+// our mips64-asm-backed chacha20poly1305 instead of AF_ALG.
+
+package chacha20poly1305
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+
+	xchacha20poly1305 "golang.org/x/crypto/chacha20poly1305"
+)
+
+type aeadCtorEntry struct {
+	name string
+	new  func(key []byte) (cipher.AEAD, error)
+}
+
+var aeadCtors = []aeadCtorEntry{
+	{"go-chacha20poly1305", xchacha20poly1305.New},
+	{"asm-chacha20poly1305", New},
+}
+
+func mustHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestAEAD_RFC8439Vector(t *testing.T) {
+	key := mustHex("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f")
+	nonce := mustHex("070000004041424344454647")
+	aad := mustHex("50515253c0c1c2c3c4c5c6c7")
+	plaintext := []byte("Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.")
+	wantCT := mustHex("d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116")
+	wantTag := mustHex("1ae10b594f09e26a7e902ecbd0600691")
+	want := append(append([]byte{}, wantCT...), wantTag...)
+
+	for _, c := range aeadCtors {
+		t.Run(c.name, func(t *testing.T) {
+			aead, err := c.new(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := aead.Seal(nil, nonce, plaintext, aad)
+			if !bytes.Equal(got, want) {
+				t.Errorf("Seal mismatch:\n got: %x\nwant: %x", got, want)
+			}
+			opened, err := aead.Open(nil, nonce, want, aad)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			if !bytes.Equal(opened, plaintext) {
+				t.Errorf("Open mismatch:\n got: %q\nwant: %q", opened, plaintext)
+			}
+		})
+	}
+}
+
+func TestAEAD_AgreesWithReference(t *testing.T) {
+	sizes := []int{0, 1, 15, 16, 17, 31, 63, 64, 65, 127, 128, 1024, 1500, 4096, 16384}
+	aadSizes := []int{0, 1, 13, 64}
+
+	var key [32]byte
+	rand.Read(key[:])
+	var nonce [12]byte
+	rand.Read(nonce[:])
+
+	ref, err := xchacha20poly1305.New(key[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range aeadCtors {
+		aead, err := c.new(key[:])
+		if err != nil {
+			t.Fatalf("%s: New: %v", c.name, err)
+		}
+		if got := aead.NonceSize(); got != 12 {
+			t.Errorf("%s: NonceSize = %d, want 12", c.name, got)
+		}
+		if got := aead.Overhead(); got != 16 {
+			t.Errorf("%s: Overhead = %d, want 16", c.name, got)
+		}
+		for _, plen := range sizes {
+			plaintext := make([]byte, plen)
+			rand.Read(plaintext)
+			for _, alen := range aadSizes {
+				aad := make([]byte, alen)
+				rand.Read(aad)
+				wantCT := ref.Seal(nil, nonce[:], plaintext, aad)
+				name := fmt.Sprintf("%s/pt=%d/aad=%d", c.name, plen, alen)
+				t.Run(name, func(t *testing.T) {
+					gotCT := aead.Seal(nil, nonce[:], plaintext, aad)
+					if !bytes.Equal(gotCT, wantCT) {
+						t.Fatalf("Seal mismatch (pt=%d aad=%d)", plen, alen)
+					}
+					pt, err := aead.Open(nil, nonce[:], wantCT, aad)
+					if err != nil {
+						t.Fatalf("Open: %v", err)
+					}
+					if !bytes.Equal(pt, plaintext) {
+						t.Fatalf("Open mismatch (pt=%d aad=%d)", plen, alen)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAEAD_OpenRejectsTamper(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+	var nonce [12]byte
+	rand.Read(nonce[:])
+	plaintext := []byte("the quick brown fox jumps over the lazy dog")
+	aad := []byte("metadata")
+
+	for _, c := range aeadCtors {
+		t.Run(c.name, func(t *testing.T) {
+			aead, err := c.new(key[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			ct := aead.Seal(nil, nonce[:], plaintext, aad)
+
+			tamper := append([]byte{}, ct...)
+			tamper[0] ^= 1
+			if _, err := aead.Open(nil, nonce[:], tamper, aad); err == nil {
+				t.Error("Open accepted tampered ciphertext")
+			}
+
+			tamper = append([]byte{}, ct...)
+			tamper[len(tamper)-1] ^= 1
+			if _, err := aead.Open(nil, nonce[:], tamper, aad); err == nil {
+				t.Error("Open accepted tampered tag")
+			}
+
+			badAAD := append([]byte{}, aad...)
+			badAAD[0] ^= 1
+			if _, err := aead.Open(nil, nonce[:], ct, badAAD); err == nil {
+				t.Error("Open accepted wrong AAD")
+			}
+
+			var badNonce [12]byte
+			copy(badNonce[:], nonce[:])
+			badNonce[0] ^= 1
+			if _, err := aead.Open(nil, badNonce[:], ct, aad); err == nil {
+				t.Error("Open accepted wrong nonce")
+			}
+		})
+	}
+}
+
+func TestAEAD_Concurrent(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+	plaintext := []byte("wireguard concurrent aead test")
+	aad := []byte("aad")
+
+	for _, c := range aeadCtors {
+		t.Run(c.name, func(t *testing.T) {
+			aead, err := c.new(key[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			const goroutines = 8
+			const iters = 100
+			var wg sync.WaitGroup
+			wg.Add(goroutines)
+			errs := make(chan error, goroutines)
+			for g := range goroutines {
+				go func(id int) {
+					defer wg.Done()
+					var nonce [12]byte
+					binary.BigEndian.PutUint64(nonce[4:], uint64(id))
+					for i := range iters {
+						binary.BigEndian.PutUint32(nonce[:4], uint32(i))
+						ct := aead.Seal(nil, nonce[:], plaintext, aad)
+						pt, err := aead.Open(nil, nonce[:], ct, aad)
+						if err != nil {
+							errs <- fmt.Errorf("goroutine %d iter %d: Open: %w", id, i, err)
+							return
+						}
+						if !bytes.Equal(pt, plaintext) {
+							errs <- fmt.Errorf("goroutine %d iter %d: plaintext mismatch", id, i)
+							return
+						}
+					}
+				}(g)
+			}
+			wg.Wait()
+			close(errs)
+			for err := range errs {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func BenchmarkAEAD_Seal(b *testing.B) { benchmarkAEAD(b, false) }
+func BenchmarkAEAD_Open(b *testing.B) { benchmarkAEAD(b, true) }
+
+func benchmarkAEAD(b *testing.B, open bool) {
+	const ptSize = 1420
+	var key [32]byte
+	rand.Read(key[:])
+	var nonce [12]byte
+	plaintext := make([]byte, ptSize)
+	rand.Read(plaintext)
+
+	for _, c := range aeadCtors {
+		b.Run(c.name, func(b *testing.B) {
+			aead, err := c.new(key[:])
+			if err != nil {
+				b.Fatal(err)
+			}
+			ctBuf := make([]byte, 0, ptSize+aead.Overhead())
+			ct := aead.Seal(ctBuf, nonce[:], plaintext, nil)
+			ptBuf := make([]byte, 0, ptSize)
+			b.SetBytes(int64(ptSize))
+			b.ResetTimer()
+			if open {
+				for range b.N {
+					if _, err := aead.Open(ptBuf[:0], nonce[:], ct, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			} else {
+				for range b.N {
+					_ = aead.Seal(ctBuf[:0], nonce[:], plaintext, nil)
+				}
+			}
+		})
+	}
+}

--- a/tsasm/mips64/chacha20poly1305/chacha20poly1305.go
+++ b/tsasm/mips64/chacha20poly1305/chacha20poly1305.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+// Package chacha20poly1305 provides a ChaCha20-Poly1305 AEAD that
+// pairs the hand-ported scalar mips64r2 ChaCha20 in tsasm/mips64/chacha20
+// with the hand-ported scalar mips64r2 Poly1305 in
+// tsasm/mips64/poly1305. Both halves are asm here.
+//
+// Only builds on big-endian GOARCH=mips64; other architectures should
+// use golang.org/x/crypto/chacha20poly1305 directly.
+package chacha20poly1305
+
+import (
+	"crypto/cipher"
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+
+	chacha "github.com/tailscale/wireguard-go/tsasm/mips64/chacha20"
+	"github.com/tailscale/wireguard-go/tsasm/mips64/poly1305"
+)
+
+const (
+	KeySize   = 32
+	NonceSize = 12
+	Overhead  = 16
+)
+
+type aead struct {
+	key [KeySize]byte
+}
+
+// New returns a chacha20poly1305 AEAD with the given 32-byte key.
+func New(key []byte) (cipher.AEAD, error) {
+	if len(key) != KeySize {
+		return nil, errors.New("chacha20poly1305: bad key length")
+	}
+	a := &aead{}
+	copy(a.key[:], key)
+	return a, nil
+}
+
+func (a *aead) NonceSize() int { return NonceSize }
+func (a *aead) Overhead() int  { return Overhead }
+
+func (a *aead) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
+	if len(nonce) != NonceSize {
+		panic("chacha20poly1305: bad nonce length")
+	}
+	ret, out := sliceForAppend(dst, len(plaintext)+Overhead)
+
+	var nonceArr [chacha.NonceSize]byte
+	copy(nonceArr[:], nonce)
+
+	// Derive the Poly1305 one-time key from the first 32 bytes of the
+	// ChaCha20 keystream at counter 0, then encrypt at counter 1.
+	var (
+		zeros   [64]byte
+		polyBuf [64]byte
+		polyKey [32]byte
+	)
+	chacha.XORKeyStream(polyBuf[:], zeros[:], &a.key, &nonceArr, 0)
+	copy(polyKey[:], polyBuf[:32])
+	chacha.XORKeyStream(out[:len(plaintext)], plaintext, &a.key, &nonceArr, 1)
+
+	tag := computeTag(additionalData, out[:len(plaintext)], &polyKey)
+	copy(out[len(plaintext):], tag[:])
+	return ret
+}
+
+func (a *aead) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	if len(nonce) != NonceSize {
+		return nil, errors.New("chacha20poly1305: bad nonce length")
+	}
+	if len(ciphertext) < Overhead {
+		return nil, errors.New("chacha20poly1305: ciphertext too short")
+	}
+	ctLen := len(ciphertext) - Overhead
+	ct := ciphertext[:ctLen]
+	receivedTag := ciphertext[ctLen:]
+
+	var nonceArr [chacha.NonceSize]byte
+	copy(nonceArr[:], nonce)
+
+	var (
+		zeros   [64]byte
+		polyBuf [64]byte
+		polyKey [32]byte
+	)
+	chacha.XORKeyStream(polyBuf[:], zeros[:], &a.key, &nonceArr, 0)
+	copy(polyKey[:], polyBuf[:32])
+
+	expectedTag := computeTag(additionalData, ct, &polyKey)
+	if subtle.ConstantTimeCompare(receivedTag, expectedTag[:]) != 1 {
+		return nil, errors.New("chacha20poly1305: message authentication failed")
+	}
+
+	ret, out := sliceForAppend(dst, ctLen)
+	chacha.XORKeyStream(out, ct, &a.key, &nonceArr, 1)
+	return ret, nil
+}
+
+var zeros16 [16]byte
+
+// computeTag streams (aad || pad16 || ct || pad16 || u64le(|aad|) ||
+// u64le(|ct|)) through a Poly1305 MAC.
+func computeTag(aad, ct []byte, polyKey *[32]byte) [16]byte {
+	var mac poly1305.MAC
+	mac.Init(polyKey)
+	mac.Write(aad)
+	if rem := len(aad) % 16; rem != 0 {
+		mac.Write(zeros16[:16-rem])
+	}
+	mac.Write(ct)
+	if rem := len(ct) % 16; rem != 0 {
+		mac.Write(zeros16[:16-rem])
+	}
+	var lenBuf [16]byte
+	binary.LittleEndian.PutUint64(lenBuf[0:8], uint64(len(aad)))
+	binary.LittleEndian.PutUint64(lenBuf[8:16], uint64(len(ct)))
+	mac.Write(lenBuf[:])
+
+	var tag [16]byte
+	mac.Sum(&tag)
+	return tag
+}
+
+func sliceForAppend(dst []byte, n int) (head, tail []byte) {
+	if total := len(dst) + n; cap(dst) >= total {
+		head = dst[:total]
+	} else {
+		head = make([]byte, total)
+		copy(head, dst)
+	}
+	tail = head[len(dst):]
+	return
+}

--- a/tsasm/mips64/poly1305/poly1305_mips64.go
+++ b/tsasm/mips64/poly1305/poly1305_mips64.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+// Package poly1305 implements Poly1305 with a hand-written scalar
+// mips64r2 inner loop modeled on Andy Polyakov's poly1305-mips.pl
+// (the 64-bit code path; openssl/Linux upstream).
+//
+// The state is held in 3 saturated 64-bit limbs
+// (h = h0 + h1*2^64 + h2*2^128, h2 ≤ ~5 with carry slack), the key
+// in 2 saturated 64-bit limbs (r = r0 + r1*2^64, with the standard
+// rMask clamp clearing the top 4 bits of each plus the bottom 2
+// of r1), and a precomputed s1 = r1 + (r1 >> 2). The s1 form lets
+// the inner loop fold the 2^130 ≡ 5 reduction into the multiplication
+// itself by replacing a multiply-by-r1 with multiply-by-s1 wherever
+// the product crosses 2^130: s1 * 4 = 5 * r1, and the missing factor
+// of 4 falls out of the limb alignment.
+//
+// Inner loop is 6 DMULTU partial products per 16-byte block (h*r is
+// 3x2 = 6 products), each followed by MFLO/MFHI + manual carry chain
+// using DADDU + SLTU. No DMADD: every accumulator step is explicit so
+// the only HI/LO traffic is the multiply itself and the immediately
+// following MFLO/MFHI -- which the MIPS r2 hardware-interlock
+// guarantees handles. (My earlier 5x26 + MULU/MADD attempts got
+// occasional wrong tags on real Cavium Octeon II and Ingenic JZ4780
+// silicon; the saturated layout sidesteps the MADD-into-accumulator
+// hazards entirely.)
+//
+// Only builds on big-endian GOARCH=mips64. The input load uses a
+// MIPS r2 DSBH+DSHD pair to byte-swap doublewords from BE memory
+// to LE numeric order; mips64le would need a separate asm without
+// that swap.
+package poly1305
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+const (
+	KeySize = 32
+	TagSize = 16
+)
+
+// macState is the layout the asm reads. r and s1 are constant after
+// Init; h is the running accumulator. Field offsets are hard-coded
+// in poly1305_mips64.s.
+type macState struct {
+	h  [3]uint64 // saturated 64-bit limbs of the running hash; offsets 0, 8, 16
+	r  [2]uint64 // saturated 64-bit limbs of the clamped key;    offsets 24, 32
+	s1 uint64    // r[1] + (r[1] >> 2); offset 40
+}
+
+// MAC is an incremental Poly1305 message-authentication code computer.
+// Single-use; not safe for concurrent use. Zero-value is not usable --
+// call Init first.
+type MAC struct {
+	state  macState
+	pad    [2]uint64 // saved key[16:32], added in Sum.
+	buffer [TagSize]byte
+	offset int
+}
+
+// New returns a fresh MAC keyed with key. Prefer (*MAC).Init for hot
+// paths; this constructor heap-allocates.
+func New(key *[KeySize]byte) *MAC {
+	m := new(MAC)
+	m.Init(key)
+	return m
+}
+
+// Init keys an existing (typically stack-allocated) MAC with key.
+func (m *MAC) Init(key *[KeySize]byte) {
+	*m = MAC{}
+	r0 := binary.LittleEndian.Uint64(key[0:8]) & 0x0FFFFFFC0FFFFFFF
+	r1 := binary.LittleEndian.Uint64(key[8:16]) & 0x0FFFFFFC0FFFFFFC
+	m.state.r[0] = r0
+	m.state.r[1] = r1
+	m.state.s1 = r1 + (r1 >> 2)
+	m.pad[0] = binary.LittleEndian.Uint64(key[16:24])
+	m.pad[1] = binary.LittleEndian.Uint64(key[24:32])
+}
+
+// poly1305Update processes blocks 16-byte chunks of msg into state.
+// padbit is 1 for full blocks (the implicit 1 at bit 128) or 0 for
+// the last partial block, which the caller has already padded with
+// a 0x01 byte.
+//
+//go:noescape
+func poly1305Update(state *macState, msg unsafe.Pointer, blocks uintptr, padbit uintptr)
+
+// Write feeds bytes into the MAC. Returns len(p), nil.
+func (m *MAC) Write(p []byte) (int, error) {
+	n := len(p)
+	if m.offset > 0 {
+		k := copy(m.buffer[m.offset:], p)
+		m.offset += k
+		if m.offset == TagSize {
+			poly1305Update(&m.state, unsafe.Pointer(&m.buffer[0]), 1, 1)
+			m.offset = 0
+		}
+		p = p[k:]
+	}
+	if blocks := len(p) / TagSize; blocks > 0 {
+		poly1305Update(&m.state, unsafe.Pointer(&p[0]), uintptr(blocks), 1)
+		p = p[blocks*TagSize:]
+	}
+	if len(p) > 0 {
+		m.offset = copy(m.buffer[:], p)
+	}
+	return n, nil
+}
+
+// Sum flushes any buffered partial block and writes the 16-byte tag
+// to out. Sum may be called multiple times; it does not consume the
+// state.
+func (m *MAC) Sum(out *[TagSize]byte) {
+	state := m.state
+	if m.offset > 0 {
+		var buf [TagSize]byte
+		copy(buf[:], m.buffer[:m.offset])
+		buf[m.offset] = 1
+		poly1305Update(&state, unsafe.Pointer(&buf[0]), 1, 0)
+	}
+	finalize(out, &state.h, &m.pad)
+}
+
+// Sum computes a Poly1305 MAC of m under key, writing the 16-byte tag
+// to out.
+func Sum(out *[TagSize]byte, m []byte, key *[KeySize]byte) {
+	var mac MAC
+	mac.Init(key)
+	mac.Write(m)
+	mac.Sum(out)
+}
+
+// finalize fully reduces h mod (2^130 - 5), adds the pad, and emits
+// the 16-byte tag in little-endian byte order. This is the same
+// algorithm as x/crypto's saturated-64 finalize, with one extra
+// upstream-style reduction step at entry: the asm inner loop puts
+// the modulo-scheduled reduction at *block start*, so when we
+// finish the message h2 still holds whatever the last multiply put
+// there (often a full 64 bits). The first three lines below replay
+// that reduction one last time to bring h2 down to its canonical
+// 0..5-ish range.
+func finalize(out *[TagSize]byte, h *[3]uint64, pad *[2]uint64) {
+	h0, h1, h2 := h[0], h[1], h[2]
+
+	// Reduce h2's high bits back into h0 via the 2^130 ≡ 5 fold.
+	residue := (h2 >> 2) + ((h2 >> 2) << 2) // = (h2 >> 2) * 5
+	h2 &= 3
+	var c uint64
+	h0, c = bitsAdd64(h0, residue, 0)
+	h1, c = bitsAdd64(h1, 0, c)
+	h2 += c
+
+	// Constants for h - p where p = 2^130 - 5.
+	const (
+		p0 uint64 = 0xFFFFFFFFFFFFFFFB
+		p1 uint64 = 0xFFFFFFFFFFFFFFFF
+		p2 uint64 = 0x0000000000000003
+	)
+
+	// t = h - p with borrow tracking. If t doesn't borrow out of
+	// the high limb we're in canonical form already.
+	var b uint64
+	t0, b := bitsSub64(h0, p0, 0)
+	var t1 uint64
+	t1, b = bitsSub64(h1, p1, b)
+	_, b = bitsSub64(h2, p2, b)
+
+	// Constant-time select: h if h < p (b=1), else t.
+	h0 = select64(b, h0, t0)
+	h1 = select64(b, h1, t1)
+
+	// tag = (h + pad) mod 2^128.
+	h0, c = bitsAdd64(h0, pad[0], 0)
+	h1, _ = bitsAdd64(h1, pad[1], c)
+
+	binary.LittleEndian.PutUint64(out[0:], h0)
+	binary.LittleEndian.PutUint64(out[8:], h1)
+}
+
+// bitsSub64 mirrors math/bits.Sub64; inlined here to keep this
+// package free of any unusual import surface.
+func bitsSub64(x, y, borrow uint64) (diff, borrowOut uint64) {
+	diff = x - y - borrow
+	borrowOut = ((^x & y) | (^(x ^ y) & diff)) >> 63
+	return
+}
+
+func bitsAdd64(x, y, carry uint64) (sum, carryOut uint64) {
+	sum = x + y + carry
+	carryOut = ((x & y) | ((x | y) & ^sum)) >> 63
+	return
+}
+
+func select64(v, x, y uint64) uint64 {
+	mask := ^(v - 1)
+	return (x & mask) | (y & ^mask)
+}

--- a/tsasm/mips64/poly1305/poly1305_mips64.s
+++ b/tsasm/mips64/poly1305/poly1305_mips64.s
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+#include "textflag.h"
+
+// poly1305Update(state *macState, msg unsafe.Pointer, blocks uintptr, padbit uintptr)
+//
+// Hand-translated from openssl/Linux poly1305-mips.pl (Andy Polyakov,
+// dual-licensed BSD-3-Clause / OpenSSL); the 64-bit code path. 3x64
+// saturated h, 2x64 saturated r, plus precomputed s1 = r1 + (r1>>2)
+// folded into the multiply to absorb the 2^130 ≡ 5 reduction.
+//
+// Per 16-byte block:
+//
+//   * Modulo-scheduled fold of h2's high bits back into h0 via *5
+//     (h2 keeps its low 2 bits, the rest contributes (h2>>2)*5 to
+//     h0 ahead of the input add).
+//   * d = h + input + residue, with carry chained into d2 (= h2 +
+//     padbit). For full blocks padbit=1 (the implicit bit at 2^128);
+//     the final partial block is padded by the caller and passes
+//     padbit=0.
+//   * h = d * r mod (2^130-5) via 6 DMULTU partial products
+//     (d0*r0, d1*s1, d0*r1, d1*r0, d2*s1, d2*r0). Each multiply is
+//     followed only by MFLO/MFHI -- no MADD-into-accumulator that
+//     would chain through the multiplier's HI/LO state in a way the
+//     spec's hardware-interlock doesn't cleanly cover.
+//
+// Register usage (Plan 9 names):
+//
+//   R4  state ptr     R8   h0          R14  d0 / in0
+//   R5  msg ptr       R9   h1          R15  d1 / in1
+//   R6  blocks count  R10  h2          R16  d2
+//   R7  padbit        R11  r0          R17  tmp0
+//                     R12  r1          R18  tmp1
+//                     R13  s1          R19  tmp2
+//                                      R20  tmp3
+//
+// R22 (REGCTXT) is left alone -- this asm runs from a //go:noescape
+// direct call so REGCTXT is unset on entry, but staying off it keeps
+// the function safe to call through a function-value too.
+TEXT ·poly1305Update(SB), NOSPLIT|NOFRAME, $0-32
+	MOVV	state+0(FP), R4
+	MOVV	msg+8(FP), R5
+	MOVV	blocks+16(FP), R6
+	MOVV	padbit+24(FP), R7
+
+	BEQ	R6, done
+
+	// Load h, r, s1 from the macState struct.
+	MOVV	0(R4), R8
+	MOVV	8(R4), R9
+	MOVV	16(R4), R10
+	MOVV	24(R4), R11
+	MOVV	32(R4), R12
+	MOVV	40(R4), R13
+
+block_loop:
+	// Read 16 bytes of input as 2 little-endian u64s. On big-endian
+	// MIPS, MOVV reads BE byte order; DSBH+DSHD swap to LE.
+	MOVV	0(R5), R14
+	DSBH	R14, R14
+	DSHD	R14, R14
+	MOVV	8(R5), R15
+	DSBH	R15, R15
+	DSHD	R15, R15
+
+	// Modulo-scheduled reduction: fold h2's bits >=2 back into the
+	// low limb via *5 ahead of the input add. After this h2 has at
+	// most 2 bits left.
+	SRLV	$2, R10, R18      // R18 = h2 >> 2
+	AND	$3, R10, R10      // h2 &= 3
+	SLLV	$2, R18, R17      // R17 = (h2 >> 2) << 2
+
+	// d0 = h0 + in0 + 5*(h2>>2). The 5*(h2>>2) factor is built as
+	// (h2>>2)*4 + (h2>>2) below.
+	ADDVU	R8, R14, R14      // d0 = h0 + in0
+	ADDVU	R17, R18          // R18 = (h2>>2)*5
+	SGTU	R8, R14, R17      // R17 = carry from d0 = h0 + in0
+	ADDVU	R18, R14          // d0 += residue
+	SGTU	R18, R14, R18     // R18 = carry from d0 += residue
+
+	// d1 = h1 + in1 + (carry chain).
+	ADDVU	R9, R15, R15      // d1 = h1 + in1
+	ADDVU	R18, R17          // R17 += R18 (combine carries)
+	SGTU	R9, R15, R18      // R18 = carry from d1 = h1 + in1
+	ADDVU	R17, R15          // d1 += R17 (carries from d0)
+
+	// First multiply: d0 * r0. h0 := lo, h1 := hi.
+	MULVU	R11, R14
+	ADDVU	R10, R7, R16      // d2 = h2 + padbit (uses R7=padbit)
+	SGTU	R17, R15, R17     // R17 = carry from d1 += R17
+	MOVV	LO, R8
+	MOVV	HI, R9
+
+	// Second multiply: d1 * s1. The s1 = r1 + (r1>>2) form makes
+	// (d1 * s1) * 4 = d1 * 5 * r1, i.e. multiplying by s1 absorbs
+	// the *5 reduction at 2^130 (the missing /4 falls out of the
+	// limb shift).
+	MULVU	R13, R15
+	ADDVU	R18, R16          // d2 += carry (from d1=h1+in1)
+	ADDVU	R17, R16          // d2 += carry (from d1 += R17)
+	MOVV	LO, R17
+	MOVV	HI, R18
+
+	// Third multiply: d0 * r1. tmp2 := lo, h2 := hi.
+	MULVU	R12, R14
+	MOVV	LO, R19
+	MOVV	HI, R10
+	ADDVU	R17, R8           // h0 += lo(d1*s1)
+	ADDVU	R18, R9           // h1 += hi(d1*s1)
+	SGTU	R17, R8, R17      // carry from h0 += lo(d1*s1)
+
+	// Fourth multiply: d1 * r0.
+	MULVU	R11, R15
+	ADDVU	R17, R9           // h1 += carry
+	ADDVU	R19, R9           // h1 += lo(d0*r1)
+	MOVV	LO, R17
+	MOVV	HI, R18
+
+	// Fifth multiply: d2 * s1. Only LO is used; HI is bounded
+	// small and folded by the carry propagation below.
+	MULVU	R13, R16
+	SGTU	R19, R9, R19      // carry from h1 += lo(d0*r1)
+	ADDVU	R19, R10          // h2 += that carry
+	MOVV	LO, R19
+
+	// Sixth multiply: d2 * r0. tmp3 := lo (HI is out of bounds
+	// for the saturated layout).
+	MULVU	R11, R16
+	ADDVU	R17, R9           // h1 += lo(d1*r0)
+	ADDVU	R18, R10          // h2 += hi(d1*r0)
+	MOVV	LO, R20
+	SGTU	R17, R9, R17      // carry from h1 += lo(d1*r0)
+	ADDVU	R17, R10          // h2 += that carry
+
+	// Final two cross-product chunks fold in.
+	ADDVU	R19, R9           // h1 += lo(d2*s1)
+	SGTU	R19, R9, R19      // carry from h1 += lo(d2*s1)
+	ADDVU	R19, R10          // h2 += that carry
+	ADDVU	R20, R10          // h2 += lo(d2*r0)
+
+	// Loop.
+	ADDV	$16, R5
+	SUBVU	$1, R6
+	BNE	R6, block_loop
+
+	// Store h back into state.
+	MOVV	R8, 0(R4)
+	MOVV	R9, 8(R4)
+	MOVV	R10, 16(R4)
+
+done:
+	RET

--- a/tsasm/mips64/poly1305/poly1305_test.go
+++ b/tsasm/mips64/poly1305/poly1305_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build mips64
+
+package poly1305
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	xpoly1305 "golang.org/x/crypto/poly1305"
+)
+
+// RFC 8439 §2.5.2 test vector.
+func TestRFC8439Vector(t *testing.T) {
+	keyHex := "85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b"
+	src := "Cryptographic Forum Research Group"
+	msg := make([]byte, len(src))
+	copy(msg, src)
+	wantHex := "a8061dc1305136c6c22b8baf0c0127a9"
+
+	var key [32]byte
+	mustHex(t, key[:], keyHex)
+	wantTag := mustHexBytes(t, wantHex)
+
+	var got [16]byte
+	Sum(&got, msg, &key)
+	if !bytes.Equal(got[:], wantTag) {
+		t.Errorf("Sum mismatch:\n got %x\nwant %x", got, wantTag)
+	}
+}
+
+// Cross-check against golang.org/x/crypto/poly1305 over a sweep of
+// lengths.
+func TestAgainstReference(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+
+	for _, n := range []int{0, 1, 7, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 1023, 1024, 1436, 4096} {
+		t.Run(fmt.Sprintf("len=%d", n), func(t *testing.T) {
+			msg := make([]byte, n)
+			rand.Read(msg)
+
+			var got [16]byte
+			Sum(&got, msg, &key)
+
+			var want [16]byte
+			xpoly1305.Sum(&want, msg, &key)
+
+			if !bytes.Equal(got[:], want[:]) {
+				t.Errorf("mismatch (len=%d):\n got %x\nwant %x", n, got, want)
+			}
+		})
+	}
+}
+
+// TestIncrementalWrite stresses the buffer-merge path that intermittently
+// failed on the earlier 5x26 attempt: many small Writes, varying chunk
+// alignment, then Sum.
+func TestIncrementalWrite(t *testing.T) {
+	var key [32]byte
+	rand.Read(key[:])
+
+	full := make([]byte, 4096)
+	rand.Read(full)
+
+	var want [16]byte
+	xpoly1305.Sum(&want, full, &key)
+
+	for _, chunk := range []int{1, 7, 15, 16, 17, 64, 1024} {
+		t.Run(fmt.Sprintf("chunk=%d", chunk), func(t *testing.T) {
+			var mac MAC
+			mac.Init(&key)
+			for i := 0; i < len(full); i += chunk {
+				j := min(i+chunk, len(full))
+				mac.Write(full[i:j])
+			}
+			var got [16]byte
+			mac.Sum(&got)
+			if !bytes.Equal(got[:], want[:]) {
+				t.Errorf("chunk=%d mismatch:\n got %x\nwant %x", chunk, got, want)
+			}
+		})
+	}
+}
+
+func mustHex(t *testing.T, dst []byte, s string) {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) != len(dst) {
+		t.Fatalf("hex length %d, want %d", len(b), len(dst))
+	}
+	copy(dst, b)
+}
+
+func mustHexBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// BenchmarkSum compares our asm Sum against x/crypto/poly1305 across
+// the sizes that show up on the WireGuard data path.
+func BenchmarkSum(b *testing.B) {
+	for _, size := range []int{64, 1436, 4096, 16384} {
+		var key [32]byte
+		rand.Read(key[:])
+		msg := make([]byte, size)
+		rand.Read(msg)
+		b.Run(fmt.Sprintf("%d/asm", size), func(b *testing.B) {
+			var tag [16]byte
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				Sum(&tag, msg, &key)
+			}
+		})
+		b.Run(fmt.Sprintf("%d/xcrypto", size), func(b *testing.B) {
+			var tag [16]byte
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for range b.N {
+				xpoly1305.Sum(&tag, msg, &key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
golang.org/x/crypto ships no ChaCha20 or Poly1305 assembly for any
of the MIPS GOARCHes, so the WireGuard data-path AEAD on MIPS
boards (EdgeRouters, CI20-class dev boards, MikroTik / OpenWrt
routers, ...) falls back to a slow pure-Go path -- ~3-9 MB/s
depending on chip. This adds hand-written scalar mips32r2 /
mips64r2 inner loops for both halves and wires them into the
WireGuard data path via device/aead_mips{32,64}.go.

ChaCha20 (one .s per GOARCH endian-bucket; the two 32-bit
variants share a Go wrapper):

    tsasm/mips64/chacha20/chacha20_mips64.s   (mips64 BE)
    tsasm/mips32/chacha20/chacha20_mips_be.s  (mips BE)
    tsasm/mips32/chacha20/chacha20_mips_le.s  (mipsle LE)

All 16 state words live in registers across 20 rounds. Rotates
use MIPS r2 ROTR with the four left-rotate counts folded to
right-rotates (16, 20, 24, 25). On BE, input and output words
are byte-swapped with a WSBH+ROTR16 pair so the keystream comes
out in little-endian order; the LE variant drops those pairs.

Poly1305 follows openssl/Linux poly1305-mips.pl (Andy Polyakov,
dual-licensed BSD-3-Clause / OpenSSL):

    tsasm/mips64/poly1305/poly1305_mips64.s   (mips64 BE; 3x64 saturated)
    tsasm/mips32/poly1305/poly1305_mips_be.s  (mips BE; 5x32 saturated)
    tsasm/mips32/poly1305/poly1305_mips_le.s  (mipsle LE; 5x32 saturated)

Saturated limbs; precomputed s_i = r_i + (r_i >> 2) absorbs the
2^130 ≡ 5 reduction into the inner multiplications. Each partial
product is its own MULTU/DMULTU + MFLO + MFHI + manual ADDU/SGTU
carry chain -- no MADDU into the multiplier accumulator, which
sidesteps an HI/LO accumulator-chain hazard that turns up
intermittently on real Cavium Octeon II and Ingenic JZ4780
silicon. Upstream's modulo-scheduled reduction runs at block
start, so finalize() replays it once more before subtracting p.

The asm avoids R26 and R27 (k0/k1, kernel-clobbered on MIPS Linux
-- the kernel can wipe them at any interrupt or exception). The
usable Plan 9 MIPS register set is R2..R22 + R24..R25 only.

Setting TS_WG_ASM=0 in the environment forces the pure-Go
x/crypto implementation, as an escape hatch for hardware
regressions or asm bugs (matches the arm32 wiring).

Performance, 1420-byte payload (typical WireGuard packet),
median of three runs, go1.26.3:

    Hardware                                                pure-Go   asm
    EdgeRouter Pro 8 (mips64 / Cavium Octeon II Pass 1)
        ChaCha20 alone                                      10.2     52.3 MB/s   (5.1x)
        Poly1305 alone                                     100.0    292.8 MB/s   (2.9x)
        AEAD Seal                                            9.0     40.2 MB/s   (4.5x)
    CI20 dev board (mipsle / Ingenic JZ4780)
        ChaCha20 alone                                      11.3     46.0 MB/s   (4.1x)
        Poly1305 alone                                      23.1    104.0 MB/s   (4.5x)
        AEAD Seal                                            7.2     29.7 MB/s   (4.1x)
    TP-Link TL-WDR4300 v1 (mips / Atheros AR9344 / 74Kc; softfloat)
        ChaCha20 alone                                       4.7     16.3 MB/s   (3.5x)
        Poly1305 alone                                      11.3     34.5 MB/s   (3.0x)
        AEAD Seal                                            3.1      9.7 MB/s   (3.1x)

Tested / coverage:

    GOARCH     ChaCha20   Poly1305   Tested on
    mips64     yes        yes        EdgeRouter Pro 8 (Octeon II Pass 1, kernel 4.9)
    mipsle     yes        yes        CI20 dev board (Ingenic JZ4780, kernel 3.18.3)
    mips       yes        yes        TP-Link TL-WDR4300 v1 (AR9344 / 74Kc, kernel 6.12)
    mips64le   no         no         falls back to x/crypto -- no LE 64-bit MIPS hardware

Build note for FPU-less MIPS SoCs (most OpenWrt-targeted Atheros
/ Qualcomm WiSoCs, including the WDR4300's AR9344): default
GOMIPS=hardfloat binaries SIGILL on first FP-using runtime
instruction. Use GOMIPS=softfloat. The asm itself is pure
integer; this is only a Go runtime/binary concern.

Toolchain note: Go 1.26.0 and 1.26.1 panic at first goroutine
wakeup on Linux <5.1 MIPS because of a wrong _ENOSYS constant in
the new futex_time64 -> futex_time32 fallback (MIPS ENOSYS is 89,
the patch used the asm-generic 38). Fixed in 1.26.2 / 1.26.3.

Updates tailscale/tailscale#7053
