### PR TITLE
device: add peer session state callback

### DIFF
--- a/cmd/check-lockorder/registry.go
+++ b/cmd/check-lockorder/registry.go
@@ -78,6 +78,7 @@ var trackedLocks = []TrackedLock{
 	{ID: "Device.net", OwnerType: "Device", FieldPath: "net", Kind: ReadWriteMutex, DefType: "Device", DefPath: "net"},
 	{ID: "Device.staticIdentity", OwnerType: "Device", FieldPath: "staticIdentity", Kind: ReadWriteMutex, DefType: "Device", DefPath: "staticIdentity"},
 	{ID: "Device.peers", OwnerType: "Device", FieldPath: "peers", Kind: ReadWriteMutex, DefType: "Device", DefPath: "peers"},
+	{ID: "Device.sessionState", OwnerType: "Device", FieldPath: "sessionState", Kind: PlainMutex, DefType: "Device", DefPath: "sessionState"},
 	{ID: "Device.allowedips.mu", OwnerType: "Device", FieldPath: "allowedips.mu", Kind: ReadWriteMutex, DefType: "AllowedIPs", DefPath: "mu"},
 	{ID: "Device.indexTable", OwnerType: "Device", FieldPath: "indexTable", Kind: ReadWriteMutex, DefType: "IndexTable", DefPath: ""},
 	{ID: "Device.cookieChecker", OwnerType: "Device", FieldPath: "cookieChecker", Kind: ReadWriteMutex, DefType: "CookieChecker", DefPath: ""},

--- a/device/device.go
+++ b/device/device.go
@@ -61,6 +61,11 @@ type Device struct {
 		lookupFunc   PeerLookupFunc // or nil if unused
 	}
 
+	sessionState struct {
+		sync.Mutex // serializes PeerSessionStateFunc calls and protects peer.sessionState
+		fn         PeerSessionStateFunc
+	}
+
 	rate struct {
 		underLoadUntil atomic.Int64
 		limiter        ratelimiter.Ratelimiter
@@ -483,6 +488,34 @@ type PeerLookupFunc func(NoisePublicKey) (_ *NewPeerConfig, ok bool)
 // See [Device.SetPeerByIPPacketFunc] and [Device.SetPeerLookupFunc].
 type PeerByIPPacketFunc func(src, dst netip.Addr, ipPkt []byte) (_ NoisePublicKey, ok bool)
 
+// PeerSessionState is the current WireGuard session state for a peer.
+type PeerSessionState uint8
+
+const (
+	// PeerSessionNone means there is no handshake in progress and no session key
+	// material retained for this peer.
+	PeerSessionNone PeerSessionState = iota
+
+	// PeerSessionHandshake means a handshake is in progress for this peer, but
+	// there is not currently a usable WireGuard session.
+	PeerSessionHandshake
+
+	// PeerSessionEstablished means the peer has a completed WireGuard session
+	// with usable session key material.
+	PeerSessionEstablished
+
+	// PeerSessionExpired means the peer's session key material is no longer
+	// considered usable, but final key cleanup or lazy peer removal may not have
+	// happened yet.
+	PeerSessionExpired
+)
+
+// PeerSessionStateFunc is called when a peer's WireGuard session state changes.
+//
+// Calls are serialized per Device and delivered in transition order. The
+// callback must be cheap and must not call back into Device.
+type PeerSessionStateFunc func(peer NoisePublicKey, state PeerSessionState)
+
 // SetPeerLookupFunc sets the function used to look up peers by public key
 // when receiving packets for unknown peers.
 func (device *Device) SetPeerLookupFunc(f PeerLookupFunc) {
@@ -498,6 +531,18 @@ func (device *Device) SetPeerByIPPacketFunc(f PeerByIPPacketFunc) {
 	defer device.allowedips.mu.Unlock()
 	device.allowedips.peerByIPPacketFunc = f
 	device.allowedips.device = device
+}
+
+// SetSessionStateFunc sets the function used to observe peer WireGuard session
+// state changes.
+//
+// It does not replay current state. Callers that need a complete view should set
+// it before peers are started or lazily created, and maintain any snapshots,
+// sequence numbers, and pubsub state outside wireguard-go.
+func (device *Device) SetSessionStateFunc(f PeerSessionStateFunc) {
+	device.sessionState.Lock()
+	defer device.sessionState.Unlock()
+	device.sessionState.fn = f
 }
 
 func (device *Device) Close() {

--- a/device/peer.go
+++ b/device/peer.go
@@ -18,14 +18,16 @@ import (
 )
 
 type Peer struct {
-	isRunning         atomic.Bool
-	keypairs          Keypairs
-	handshake         Handshake
-	device            *Device
-	stopping          sync.WaitGroup // routines pending stop
-	txBytes           atomic.Uint64  // bytes send to peer (endpoint)
-	rxBytes           atomic.Uint64  // bytes received from peer
-	lastHandshakeNano atomic.Int64   // nano seconds since epoch
+	isRunning          atomic.Bool
+	keypairs           Keypairs
+	handshake          Handshake
+	device             *Device
+	stopping           sync.WaitGroup   // routines pending stop
+	txBytes            atomic.Uint64    // bytes send to peer (endpoint)
+	rxBytes            atomic.Uint64    // bytes received from peer
+	lastHandshakeNano  atomic.Int64     // nano seconds since epoch
+	sessionExpiresNano atomic.Int64     // nano seconds since epoch
+	sessionState       PeerSessionState // guarded by device.sessionState.Mutex
 
 	// deleteOnIdle indicates whether the peer should be deleted when idle
 	// because it was auto-created via a Device.PeerLookupFunc.
@@ -44,6 +46,7 @@ type Peer struct {
 		retransmitHandshake     *Timer
 		sendKeepalive           *Timer
 		newHandshake            *Timer
+		sessionExpired          *Timer
 		zeroKeyMaterial         *Timer
 		persistentKeepalive     *Timer
 		handshakeAttempts       atomic.Uint32
@@ -252,6 +255,10 @@ func (peer *Peer) Start() {
 
 func (peer *Peer) ZeroAndFlushAll() {
 	device := peer.device
+	peer.sessionExpiresNano.Store(0)
+	if peer.timers.sessionExpired != nil {
+		peer.timers.sessionExpired.Del()
+	}
 
 	// clear key pairs
 
@@ -274,6 +281,7 @@ func (peer *Peer) ZeroAndFlushAll() {
 	handshake.mutex.Unlock()
 
 	peer.FlushStagedPackets()
+	peer.noteSessionState(PeerSessionNone)
 }
 
 func (peer *Peer) ExpireCurrentKeypairs() {
@@ -293,6 +301,9 @@ func (peer *Peer) ExpireCurrentKeypairs() {
 		next.sendNonce.Store(RejectAfterMessages)
 	}
 	keypairs.Unlock()
+
+	peer.sessionExpiresNano.Store(0)
+	peer.noteSessionState(PeerSessionExpired)
 }
 
 func (peer *Peer) Stop() {
@@ -313,6 +324,52 @@ func (peer *Peer) Stop() {
 	peer.device.queue.encryption.wg.Done() // no more writes to encryption queue from us
 
 	peer.ZeroAndFlushAll()
+}
+
+func (peer *Peer) noteSessionState(state PeerSessionState) {
+	device := peer.device
+	device.sessionState.Lock()
+	defer device.sessionState.Unlock()
+
+	if peer.sessionState == state {
+		return
+	}
+	peer.sessionState = state
+	if f := device.sessionState.fn; f != nil {
+		f(peer.handshake.remoteStatic, state)
+	}
+}
+
+func (peer *Peer) noteSessionHandshakeStarted() {
+	device := peer.device
+	device.sessionState.Lock()
+	defer device.sessionState.Unlock()
+
+	switch peer.sessionState {
+	case PeerSessionEstablished:
+		return
+	case PeerSessionHandshake:
+		return
+	}
+	peer.sessionState = PeerSessionHandshake
+	if f := device.sessionState.fn; f != nil {
+		f(peer.handshake.remoteStatic, PeerSessionHandshake)
+	}
+}
+
+func (peer *Peer) noteSessionHandshakeStopped() {
+	state := PeerSessionNone
+	if peer.hasKeyMaterial() {
+		state = PeerSessionExpired
+	}
+	peer.noteSessionState(state)
+}
+
+func (peer *Peer) hasKeyMaterial() bool {
+	keypairs := &peer.keypairs
+	keypairs.RLock()
+	defer keypairs.RUnlock()
+	return keypairs.previous != nil || keypairs.current != nil || keypairs.next.Load() != nil
 }
 
 func (peer *Peer) SetEndpointFromPacket(endpoint conn.Endpoint) {

--- a/device/sessionstate_test.go
+++ b/device/sessionstate_test.go
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+type sessionStateEvent struct {
+	peer  NoisePublicKey
+	state PeerSessionState
+}
+
+func TestSessionStateFuncTransitions(t *testing.T) {
+	dev := newTestDevice(t)
+	peerKey := NoisePublicKey{1}
+	peer, err := dev.NewPeer(peerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []sessionStateEvent
+	dev.SetSessionStateFunc(func(peer NoisePublicKey, state PeerSessionState) {
+		got = append(got, sessionStateEvent{peer, state})
+	})
+	defer dev.SetSessionStateFunc(nil)
+
+	peer.noteSessionHandshakeStarted()
+	peer.noteSessionHandshakeStarted()
+	peer.timersSessionDerived()
+	peer.timersSessionDerived()
+	peer.sessionExpiresNano.Store(time.Now().Add(-time.Second).UnixNano())
+	expiredSession(peer)
+	expiredSession(peer)
+	peer.ZeroAndFlushAll()
+	peer.ZeroAndFlushAll()
+
+	want := []sessionStateEvent{
+		{peerKey, PeerSessionHandshake},
+		{peerKey, PeerSessionEstablished},
+		{peerKey, PeerSessionExpired},
+		{peerKey, PeerSessionNone},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("session events = %#v; want %#v", got, want)
+	}
+}
+
+func TestSessionStateHandshakeWhileEstablished(t *testing.T) {
+	dev := newTestDevice(t)
+	peerKey := NoisePublicKey{2}
+	peer, err := dev.NewPeer(peerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []PeerSessionState
+	dev.SetSessionStateFunc(func(peer NoisePublicKey, state PeerSessionState) {
+		if peer != peerKey {
+			t.Fatalf("callback peer = %v; want %v", peer, peerKey)
+		}
+		got = append(got, state)
+	})
+	defer dev.SetSessionStateFunc(nil)
+
+	peer.timersSessionDerived()
+	peer.noteSessionHandshakeStarted()
+
+	want := []PeerSessionState{PeerSessionEstablished}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("session states = %#v; want %#v", got, want)
+	}
+}
+
+func TestSessionStateHandshakeStopped(t *testing.T) {
+	dev := newTestDevice(t)
+	peerKey := NoisePublicKey{3}
+	peer, err := dev.NewPeer(peerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []PeerSessionState
+	dev.SetSessionStateFunc(func(peer NoisePublicKey, state PeerSessionState) {
+		if peer != peerKey {
+			t.Fatalf("callback peer = %v; want %v", peer, peerKey)
+		}
+		got = append(got, state)
+	})
+	defer dev.SetSessionStateFunc(nil)
+
+	peer.noteSessionHandshakeStarted()
+	peer.noteSessionHandshakeStopped()
+	peer.noteSessionHandshakeStarted()
+	peer.keypairs.Lock()
+	peer.keypairs.current = &Keypair{}
+	peer.keypairs.Unlock()
+	peer.noteSessionHandshakeStopped()
+
+	want := []PeerSessionState{
+		PeerSessionHandshake,
+		PeerSessionNone,
+		PeerSessionHandshake,
+		PeerSessionExpired,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("session states = %#v; want %#v", got, want)
+	}
+}

--- a/device/timers.go
+++ b/device/timers.go
@@ -95,6 +95,7 @@ func expiredRetransmitHandshake(peer *Peer) {
 		if peer.timersActive() && !peer.timers.zeroKeyMaterial.IsPending() {
 			peer.timers.zeroKeyMaterial.Mod(RejectAfterTime * 3)
 		}
+		peer.noteSessionHandshakeStopped()
 	} else {
 		peer.timers.handshakeAttempts.Add(1)
 		peer.device.log.Verbosef("%s - Handshake did not complete after %d seconds, retrying (try %d)", peer, int(RekeyTimeout.Seconds()), peer.timers.handshakeAttempts.Load()+1)
@@ -134,6 +135,15 @@ func expiredZeroKeyMaterial(peer *Peer) {
 		// peerfunc created it again after. We might lose some packets.
 		go peer.device.RemovePeer(peer.handshake.remoteStatic)
 	}
+}
+
+func expiredSession(peer *Peer) {
+	expires := peer.sessionExpiresNano.Load()
+	if expires == 0 || time.Now().UnixNano() < expires {
+		return
+	}
+	peer.device.log.Verbosef("%s - Session expired after %d seconds", peer, int(RejectAfterTime.Seconds()))
+	peer.noteSessionState(PeerSessionExpired)
 }
 
 func expiredPersistentKeepalive(peer *Peer) {
@@ -179,6 +189,7 @@ func (peer *Peer) timersHandshakeInitiated() {
 	if peer.timersActive() {
 		peer.timers.retransmitHandshake.Mod(RekeyTimeout + time.Millisecond*time.Duration(fastrandn(RekeyTimeoutJitterMaxMs)))
 	}
+	peer.noteSessionHandshakeStarted()
 }
 
 /* Should be called after a handshake response message is received and processed or when getting key confirmation via the first data message. */
@@ -194,8 +205,11 @@ func (peer *Peer) timersHandshakeComplete() {
 /* Should be called after an ephemeral key is created, which is before sending a handshake response or after receiving a handshake response. */
 func (peer *Peer) timersSessionDerived() {
 	if peer.timersActive() {
+		peer.sessionExpiresNano.Store(time.Now().Add(RejectAfterTime).UnixNano())
+		peer.timers.sessionExpired.Mod(RejectAfterTime)
 		peer.timers.zeroKeyMaterial.Mod(RejectAfterTime * 3)
 	}
+	peer.noteSessionState(PeerSessionEstablished)
 }
 
 /* Should be called before a packet with authentication -- keepalive, data, or handshake -- is sent, or after one is received. */
@@ -210,6 +224,7 @@ func (peer *Peer) timersInit() {
 	peer.timers.retransmitHandshake = peer.NewTimer(expiredRetransmitHandshake)
 	peer.timers.sendKeepalive = peer.NewTimer(expiredSendKeepalive)
 	peer.timers.newHandshake = peer.NewTimer(expiredNewHandshake)
+	peer.timers.sessionExpired = peer.NewTimer(expiredSession)
 	peer.timers.zeroKeyMaterial = peer.NewTimer(expiredZeroKeyMaterial)
 	peer.timers.persistentKeepalive = peer.NewTimer(expiredPersistentKeepalive)
 }
@@ -224,6 +239,7 @@ func (peer *Peer) timersStop() {
 	peer.timers.retransmitHandshake.DelSync()
 	peer.timers.sendKeepalive.DelSync()
 	peer.timers.newHandshake.DelSync()
+	peer.timers.sessionExpired.DelSync()
 	peer.timers.zeroKeyMaterial.DelSync()
 	peer.timers.persistentKeepalive.DelSync()
 }


### PR DESCRIPTION
Add a minimal callback API for observing WireGuard peer session state
changes.

Updates tailscale/corp#42874
