### PR TITLE
tun: opt-in batched reads to recover GSO batching for non-GSO traffic (VXLAN etc.)

### DIFF
--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -447,6 +447,19 @@ func handleVirtioRead(in []byte, bufs [][]byte, sizes []int, offset int) (int, e
 	return GSOSplit(in, options, bufs, sizes, offset)
 }
 
+// maxGSOSegmentsPerRead bounds how many packets a single GSO frame read from
+// the tun may split into. Batched draining (see Read) reserves this much room in
+// bufs before each additional non-blocking read so that a GSO frame can never
+// overflow the remaining buffers. Kernel-generated GSO frames are <=64KiB and
+// segment at the connection MSS, so a 64KiB frame yields well under this many
+// segments for any realistic MSS.
+const maxGSOSegmentsPerRead = 64
+
+// batchedTUNRead enables batched tun-read draining (see Read). It is opt-in via
+// the TS_TUN_BATCHED_READ environment variable, read once at process start,
+// because it alters the read path for all traffic.
+var batchedTUNRead = os.Getenv("TS_TUN_BATCHED_READ") == "1"
+
 func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
 	tun.readOpMu.Lock()
 	defer tun.readOpMu.Unlock()
@@ -454,24 +467,73 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		readInto := bufs[0][offset:]
-		if tun.vnetHdr {
-			readInto = tun.readBuff[:]
-		}
-		n, err := tun.tunFile.Read(readInto)
-		if errors.Is(err, syscall.EBADFD) {
-			err = os.ErrClosed
-		}
+	}
+
+	// First packet: a blocking read through the runtime poller.
+	readInto := bufs[0][offset:]
+	if tun.vnetHdr {
+		readInto = tun.readBuff[:]
+	}
+	n, err := tun.tunFile.Read(readInto)
+	if errors.Is(err, syscall.EBADFD) {
+		err = os.ErrClosed
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	var total int
+	if tun.vnetHdr {
+		total, err = handleVirtioRead(readInto[:n], bufs, sizes, offset)
 		if err != nil {
 			return 0, err
 		}
-		if tun.vnetHdr {
-			return handleVirtioRead(readInto[:n], bufs, sizes, offset)
-		} else {
-			sizes[0] = n
-			return 1, nil
-		}
+	} else {
+		sizes[0] = n
+		return 1, nil
 	}
+
+	if !batchedTUNRead {
+		return total, nil
+	}
+
+	// Batched draining: collect any additional packets already queued on the
+	// tun without blocking, so that non-GSO traffic -- for example VXLAN or
+	// other UDP-encapsulated tunnels, which the kernel delivers one datagram
+	// per read because the tun cannot express tunnel segmentation offload -- is
+	// batched through the encrypt and send path the same way a single GSO
+	// superframe is. This is latency neutral: it only gathers packets already
+	// waiting, stopping at EAGAIN. Order is preserved because reads are
+	// sequential. maxGSOSegmentsPerRead slots of headroom guarantee a drained
+	// GSO frame cannot overflow the remaining buffers.
+	for total <= len(bufs)-maxGSOSegmentsPerRead {
+		nn, rerr := tun.readNonblocking(tun.readBuff[:])
+		if rerr != nil || nn == 0 {
+			break // EAGAIN (queue drained) or a transient error: return what we have.
+		}
+		np, herr := handleVirtioRead(tun.readBuff[:nn], bufs[total:], sizes[total:], offset)
+		if herr != nil {
+			break
+		}
+		total += np
+	}
+	return total, nil
+}
+
+// readNonblocking performs a single non-blocking read on the tun fd, returning
+// the number of bytes read. It returns unix.EAGAIN when no packet is queued. It
+// reads via the raw conn so the runtime poller's blocking semantics are
+// bypassed; the raw conn holds the fd mutex for the duration, so it is safe
+// against a concurrent close.
+func (tun *NativeTun) readNonblocking(buf []byte) (int, error) {
+	var n int
+	var serr error
+	if cerr := tun.tunRawConn.Control(func(fd uintptr) {
+		n, serr = unix.Read(int(fd), buf)
+	}); cerr != nil {
+		return 0, cerr
+	}
+	return n, serr
 }
 
 func (tun *NativeTun) Events() <-chan Event {


### PR DESCRIPTION
## Problem

Userspace WireGuard only reaches multi-gigabit speeds because the kernel hands the tun device a single large GSO superframe per read call. The encrypt and send pipeline then splits that frame and coalesces the segments, so the per-packet cost of a syscall plus crypto is amortized over roughly 45 segments at once.

That batching breaks down for any traffic the tun cannot describe with a segmentation offload. The most common case is UDP encapsulated tunnels such as VXLAN and Geneve. The tun has no tunnel segmentation offload, because the virtio_net_hdr has no UDP tunnel GSO type, so the kernel pre-segments the inner stream into individual datagrams and delivers them to the tun one datagram per read. The pipeline then performs roughly one sendmmsg syscall per 1300 byte datagram, which is about 45 times more syscalls than the TCP path needs for the same number of bytes.

This shows up most often with Kubernetes overlay networks running over a tailnet underlay, for example Cilium, Calico or Flannel in VXLAN mode, but it is a general problem. Any burst of independent same-flow datagrams that the kernel cannot batch into a GSO frame hits the same wall.

A CPU profile of the sender at the capped rate spends about 48 percent of its time in sendmmsg on the single per-peer sender goroutine and only about 3 percent in crypto, so the bottleneck is one syscall per packet rather than the cipher. Throughput does not improve with parallel streams to the same peer, because they all funnel through that one serial sender.

## Change

When TS_TUN_BATCHED_READ is set to 1, Read does an initial blocking read as before, then drains any packets that are already queued on the tun using non-blocking reads, packing them into the same bufs batch. The downstream pipeline then coalesces them the same way it coalesces a GSO superframe.

The drain does not add latency, because it only collects packets that are already waiting and stops as soon as a read returns EAGAIN. It preserves order, because reads stay sequential under the existing readOpMu lock. It reserves maxGSOSegmentsPerRead slots (64) before each additional read so that a drained GSO frame can never overflow the remaining buffers. The feature is off by default, and there is no behavior change unless the environment variable is set.

## Results

These numbers come from a VXLAN over WireGuard path with a single TCP stream between two 8 vCPU nodes in the same region.

| | throughput |
|---|---|
| off (default) | about 0.77 Gbit/s |
| TS_TUN_BATCHED_READ=1 | about 2.5 Gbit/s |
| raw TCP over WireGuard, for reference | about 3.3 Gbit/s |

Instrumentation confirms the mechanism. The average send batch grows from 1 packet to around 57, the UDP GSO factor grows from 1 to around 31, and the number of sendmmsg syscalls drops by roughly 10 times. Raw TCP throughput is unchanged, since it already received GSO frames before this change. Sustained 30 second transfers are byte for byte identical end to end, and the result holds with rx-udp-gro-forwarding enabled.

## Review notes

The drain issues a raw unix.Read through tunRawConn.Control while the runtime poller still owns the same fd through tunFile.Read. I believe this is safe. poll.FD.Read always attempts the syscall before parking on the poller, so a stale readiness flag costs at most one extra EAGAIN, and edge triggered epoll fires again whenever an emptied fd receives new data, regardless of how the fd was drained. That reasoning still leans on runtime internal behavior and epoll edge semantics, so it deserves a careful look. Keeping the feature behind an environment variable that defaults to off is intentional, so it can soak before anyone considers making it the default.

If you would rather surface this as a method on the device or tun instead of an environment variable, I am happy to change it.

## Related

The main tracking issue is tailscale/tailscale#11026. That issue was effectively closed out around the kernel fix in 6.8.5 and the `TS_TUN_DISABLE_UDP_GRO` workaround, both of which address the packet corruption it reported. Neither addresses the throughput, which stays roughly five times below raw WireGuard because the sender still sends one datagram per syscall. This change is the part that closes that throughput gap. The same symptom shows up in tailscale/tailscale#11320 (VXLAN over Tailscale, high CPU and no speed) and tailscale/tailscale#18372 (Docker Swarm overlay over Tailscale).

This is the sender half of the problem. The receiver half is the companion change #70, which lets UDP GRO coalesce the zero-checksum datagrams that encapsulators like Cilium emit. Each change is independent and helps on its own, and both are needed to reach the full throughput, because a single TCP stream runs at the speed of the slower side. Unlike #70, this change has no kernel-version dependency.
