### PR TITLE
tun: coalesce zero-checksum UDP datagrams in UDP GRO (VXLAN/Cilium)

### DIFF
--- a/tun/offload_linux.go
+++ b/tun/offload_linux.go
@@ -495,6 +495,19 @@ func checksumValid(pkt []byte, iphLen, proto uint8, isV6 bool) bool {
 	return ^Checksum(pkt[iphLen:], cSum) == 0
 }
 
+// udpCsumOKForGRO reports whether the UDP datagram may be coalesced. An IPv4 UDP
+// datagram with a zero checksum field carries no checksum per RFC 768 and must
+// not be validated; VXLAN encapsulators (e.g. Cilium) commonly emit these.
+func udpCsumOKForGRO(pkt []byte, iphLen uint8, isV6 bool) bool {
+	udpCsumOff := int(iphLen) + 6
+	if !isV6 && udpCsumOff+2 <= len(pkt) {
+		if pkt[udpCsumOff] == 0 && pkt[udpCsumOff+1] == 0 {
+			return true
+		}
+	}
+	return checksumValid(pkt, iphLen, unix.IPPROTO_UDP, isV6)
+}
+
 // coalesceResult represents the result of attempting to coalesce two packets.
 type coalesceResult int
 
@@ -511,11 +524,11 @@ func coalesceUDPPackets(pkt []byte, item *udpGROItem, wi *groToWrite, isV6 bool)
 	headersLen := int(item.iphLen) + udphLen
 	iov := &wi.iovs[item.outputIdx]
 	if len(*iov) == iovSinglePacketLen {
-		if item.cSumKnownInvalid || !checksumValid((*iov)[iovHeadPacketIdx], item.iphLen, unix.IPPROTO_UDP, isV6) {
+		if item.cSumKnownInvalid || !udpCsumOKForGRO((*iov)[iovHeadPacketIdx], item.iphLen, isV6) {
 			return coalesceItemInvalidCSum
 		}
 	}
-	if !checksumValid(pkt, item.iphLen, unix.IPPROTO_UDP, isV6) {
+	if !udpCsumOKForGRO(pkt, item.iphLen, isV6) {
 		return coalescePktInvalidCSum
 	}
 	*iov = append(*iov, pkt[headersLen:])

--- a/tun/offload_linux_test.go
+++ b/tun/offload_linux_test.go
@@ -274,6 +274,55 @@ func flipUDP4Checksum(b []byte) []byte {
 	return b
 }
 
+// zeroUDP4Checksum clears the UDP checksum field, which per RFC 768 signals
+// "no checksum" for IPv4 UDP. VXLAN encapsulators commonly emit such datagrams.
+func zeroUDP4Checksum(b []byte) []byte {
+	at := virtioNetHdrLen + 20 + 6 // 20 byte ipv4 header; udp csum offset is 6
+	b[at] = 0
+	b[at+1] = 0
+	return b
+}
+
+// Test_handleGRO_zeroChecksumUDPCoalesces verifies that IPv4 UDP datagrams
+// carrying a zero (absent, per RFC 768) checksum are coalesced by UDP GRO, while
+// a genuinely bad checksum is still refused. Zero-checksum outer UDP is the
+// common shape for VXLAN-encapsulated traffic (e.g. Cilium).
+func Test_handleGRO_zeroChecksumUDPCoalesces(t *testing.T) {
+	pktsIn := [][]byte{
+		zeroUDP4Checksum(udp4Packet(ip4PortA, ip4PortB, 100)), // udp4 flow 1, no checksum
+		zeroUDP4Checksum(udp4Packet(ip4PortA, ip4PortB, 100)), // udp4 flow 1, no checksum
+		zeroUDP4Checksum(udp4Packet(ip4PortA, ip4PortB, 100)), // udp4 flow 1, no checksum
+		flipUDP4Checksum(udp4Packet(ip4PortA, ip4PortC, 100)), // udp4 flow 2, genuinely bad checksum
+	}
+	want := [][]int{
+		{virtioNetHdrLen, 128, 100, 100}, // flow 1: three zero-csum datagrams coalesced
+		{virtioNetHdrLen, 128},           // flow 2: bad csum, unmerged
+	}
+
+	wi := newGROToWrite()
+	pkts := make([][]byte, len(pktsIn))
+	for k, p := range pktsIn {
+		pkts[k] = slices.Clone(p)
+	}
+	if err := handleGRO(pkts, offset, newTCPGROTable(), newUDPGROTable(), 0, &wi); err != nil {
+		t.Fatalf("handleGRO: %v", err)
+	}
+	if len(wi.iovs) != len(want) {
+		t.Fatalf("got %d outputs, want %d", len(wi.iovs), len(want))
+	}
+	for i, wantFragLens := range want {
+		iov := wi.iovs[i]
+		if len(iov) != len(wantFragLens) {
+			t.Fatalf("output[%d]: got %d fragments, want %d", i, len(iov), len(wantFragLens))
+		}
+		for j, wantLen := range wantFragLens {
+			if len(iov[j]) != wantLen {
+				t.Errorf("output[%d][%d]: got len %d, want %d", i, j, len(iov[j]), wantLen)
+			}
+		}
+	}
+}
+
 func Fuzz_handleGRO(f *testing.F) {
 	pkt0 := tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagAck, 100, 1)
 	pkt1 := tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagAck, 100, 101)


### PR DESCRIPTION
## Problem

UDP GRO will not coalesce a datagram whose UDP checksum does not validate. That is the right call for a corrupt packet, but an IPv4 UDP datagram is allowed to carry a zero checksum field, which per RFC 768 means the sender computed no checksum at all. A zero checksum is not a failed checksum, it is the absence of one, and it must not be validated.

VXLAN encapsulators commonly emit the outer UDP datagram with a zero checksum. Cilium does this by default, because its eBPF datapath sets the tunnel without the checksum flag. The result is that every encapsulated datagram fails the validation in coalesceUDPPackets and is skipped, so UDP GRO never engages for that traffic and the receiver ends up writing one datagram per writev. On a Cilium over Tailscale path the receiver coalescing factor is exactly one.

## Change

Treat an IPv4 UDP datagram whose checksum field is zero as valid for coalescing, rather than running it through checksum validation. The coalesced frame already carries NEEDS_CSUM with the pseudo-header sum, so when the kernel splits it back into segments it computes a correct checksum for each one. The datagrams that come out the far side carry a real checksum, not a zero, so nothing downstream is weakened.

IPv6 is left as is, since a zero UDP checksum is not generally valid there.

## Results

VXLAN over WireGuard, single TCP stream, kernel 7.0. On its own this change takes the receiver from one datagram per write up to roughly thirty, and throughput from about 0.54 to about 0.71 Gbit/s, with retransmits dropping to single digits. The remaining limit at that point is the sender, which still sends one datagram per syscall. Combined with batched tun reads from the companion change, the path reaches about 2.66 Gbit/s.

## Kernel dependency

This coalescing has the same kernel requirement as UDP GRO for encapsulated traffic in general. On kernels before 6.8.5 the vxlan and geneve drivers mishandle the coalesced frame, which is the corruption tracked in tailscale/tailscale#11026, and that affects valid-checksum encapsulation too. Because this change makes zero-checksum encapsulation take the same coalescing path, it inherits the same requirement, and it is governed by the same `TS_TUN_DISABLE_UDP_GRO` escape hatch. On 6.8.5 and later it is safe.

## Related

This is the receiver half of the VXLAN over Tailscale throughput problem. The sender half is the companion change that batches tun reads. Each is independent and helps on its own, and both are needed to reach the full throughput, because a single TCP stream runs at the speed of the slower side.

- tailscale/tailscale#11026
- tailscale/tailscale#11320
- tailscale/tailscale#18372
