### PR TITLE
device: convert runtime.SetFinalizer to AddCleanup

### DIFF
--- a/device/channels.go
+++ b/device/channels.go
@@ -84,7 +84,7 @@ func newAutodrainingInboundQueue(device *Device) *autodrainingInboundQueue {
 		c: make(chan *QueueInboundElementsContainer, QueueInboundSize),
 	}
 	if device.needsInboundQueueFinalizer() {
-		runtime.SetFinalizer(q, device.flushInboundQueue)
+		runtime.AddCleanup(q, device.flushInboundQueue, q.c)
 	}
 	return q
 }
@@ -95,10 +95,10 @@ func (device *Device) needsInboundQueueFinalizer() bool {
 		device.pool.inboundElementsContainer.hasAccounting()
 }
 
-func (device *Device) flushInboundQueue(q *autodrainingInboundQueue) {
+func (device *Device) flushInboundQueue(c <-chan *QueueInboundElementsContainer) {
 	for {
 		select {
-		case elemsContainer := <-q.c:
+		case elemsContainer := <-c:
 			elemsContainer.filling.Wait()
 			for _, elem := range elemsContainer.elems {
 				device.PutMessageBuffer(elem.buffer)
@@ -125,7 +125,7 @@ func newAutodrainingOutboundQueue(device *Device) *autodrainingOutboundQueue {
 		c: make(chan *QueueOutboundElementsContainer, QueueOutboundSize),
 	}
 	if device.needsOutboundQueueFinalizer() {
-		runtime.SetFinalizer(q, device.flushOutboundQueue)
+		runtime.AddCleanup(q, device.flushOutboundQueue, q.c)
 	}
 	return q
 }
@@ -136,10 +136,10 @@ func (device *Device) needsOutboundQueueFinalizer() bool {
 		device.pool.outboundElementsContainer.hasAccounting()
 }
 
-func (device *Device) flushOutboundQueue(q *autodrainingOutboundQueue) {
+func (device *Device) flushOutboundQueue(c <-chan *QueueOutboundElementsContainer) {
 	for {
 		select {
-		case elemsContainer := <-q.c:
+		case elemsContainer := <-c:
 			elemsContainer.filling.Wait()
 			for _, elem := range elemsContainer.elems {
 				device.PutMessageBuffer(elem.buffer)

--- a/device/peer.go
+++ b/device/peer.go
@@ -239,8 +239,8 @@ func (peer *Peer) Start() {
 
 	peer.timersStart()
 
-	device.flushInboundQueue(peer.queue.inbound)
-	device.flushOutboundQueue(peer.queue.outbound)
+	device.flushInboundQueue(peer.queue.inbound.c)
+	device.flushOutboundQueue(peer.queue.outbound.c)
 
 	// Use the device batch size, not the bind batch size, as the device size is
 	// the size of the batch pools.


### PR DESCRIPTION
In PR #66, we tried to address a memory leak by avoiding [runtime.SetFinalizer](https://pkg.go.dev/runtime#SetFinalizer) for [autodrainingInboundQueue](https://github.com/tailscale/wireguard-go/blob/ffb1380710289838d585b47f2d44ab49252cefa2/device/channels.go#L74-L76) and [autodrainingOutboundQueue](https://github.com/tailscale/wireguard-go/blob/ffb1380710289838d585b47f2d44ab49252cefa2/device/channels.go#L114-L116) unless there was something to do.

However, when there is work to be done, these finalizers still leak memory because they’re still holding on to a cyclical reference to q. This applies to any platform that relies on a bounded [device.WaitPool](https://pkg.go.dev/github.com/tailscale/wireguard-go/device#WaitPool), like [Android](https://github.com/tailscale/wireguard-go/blob/ffb1380710289838d585b47f2d44ab49252cefa2/device/queueconstants_android.go#L18) and [iOS](https://github.com/tailscale/wireguard-go/blob/ffb1380710289838d585b47f2d44ab49252cefa2/device/queueconstants_ios.go#L18) which both declare [PreallocatedBuffersPerPool](https://pkg.go.dev/github.com/tailscale/wireguard-go/device#PreallocatedBuffersPerPool).

This patch converts this logic to [runtime.AddCleanup](https://pkg.go.dev/runtime#AddCleanup) which is designed to avoid this problem completely.

Updates tailscale/corp#42776