### PR TITLE
device: set peer to expire unconditionally

### DIFF
--- a/device/failed_handshake_test.go
+++ b/device/failed_handshake_test.go
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"net/netip"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/tailscale/wireguard-go/conn/bindtest"
+	"github.com/tailscale/wireguard-go/tun/tuntest"
+)
+
+func newSynctestDevice(tb testing.TB) *Device {
+	tb.Helper()
+	sk, err := newPrivateKey()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	binds := bindtest.NewChannelBinds()
+	tun := tuntest.NewChannelTUN()
+	dev := NewDevice(tun.TUN(), binds[0], NewLogger(LogLevelError, ""))
+	dev.SetPrivateKey(sk)
+	tb.Cleanup(dev.Close)
+	return dev
+}
+
+func TestLazyPeerReaping(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dev := newSynctestDevice(t)
+		dev.SetPeerLookupFunc(func(pk NoisePublicKey) (*NewPeerConfig, bool) {
+			ip := netip.AddrFrom4([4]byte{10, pk[0], pk[1], pk[2]})
+			return &NewPeerConfig{AllowedIPs: []netip.Prefix{netip.PrefixFrom(ip, 32)}}, true
+		})
+		var pk NoisePublicKey
+		pk[0] = 0x42
+
+		// LookupPeer creates the peer and calls Start(), which arms the
+		// reaping timer for a lazy peer that never completes a handshake.
+		peer := dev.LookupPeer(pk)
+		if peer == nil {
+			t.Fatal("LookupPeer returned nil")
+		}
+		synctest.Wait() // let startup goroutines settle to durable block
+
+		if !peer.timers.zeroKeyMaterial.IsPending() {
+			t.Fatal("zeroKeyMaterial not armed; lazy peer would never be reaped")
+		}
+
+		// The timer fires only at the deadline: still present just before.
+		time.Sleep(RejectAfterTime*3 - time.Second)
+		synctest.Wait()
+		if _, ok := dev.LookupActivePeer(pk); !ok {
+			t.Fatal("peer reaped before RejectAfterTime*3")
+		}
+
+		// Cross the deadline: expiredZeroKeyMaterial -> RemovePeer.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		if _, ok := dev.LookupActivePeer(pk); ok {
+			t.Fatal("peer NOT reaped after RejectAfterTime*3")
+		}
+	})
+}

--- a/device/peer.go
+++ b/device/peer.go
@@ -249,6 +249,14 @@ func (peer *Peer) Start() {
 	go peer.RoutineSequentialReceiver(batchSize)
 
 	peer.isRunning.Store(true)
+
+	// A lazily-created peer that never completes a handshake otherwise never
+	// arms its reaping timer. Arm it here, while running under state.Lock, so
+	// it's reclaimed after RejectAfterTime*3 of no session and is guaranteed to
+	// be torn down by a matching Stop. A completed handshake re-Mods it.
+	if peer.deleteOnIdle {
+		peer.timers.zeroKeyMaterial.Mod(RejectAfterTime * 3)
+	}
 }
 
 func (peer *Peer) ZeroAndFlushAll() {


### PR DESCRIPTION
e3ac4a0afb4e introduced lightweight API that can be used instead of UAPI to reconfigure peers. Peer state created via the new PeerLookupFunc is not set to expire until the handshake succeeds, making device leak two goroutines and a set of buffers for each failed handshake. 

This change arms the expiry timer before the handshake gets to proceed.

Updates tailscale/tailscale#20183 