### PR TITLE
Revert "CODEOWNERS: initial policy"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
-# Every file in this repo requires review from the dataplane team.
-* @tailscale/dataplane
+# No CODEOWNERS.
+#
+# Copy @tailscale/dataplane on changes.
+#
+# Do not add to this list without wide discussion.
+# See https://github.com/tailscale/corp/issues/13972
+# (Same policy as https://github.com/tailscale/tailscale/blob/main/CODEOWNERS etc)


### PR DESCRIPTION
This reverts commit 6094c69ffe114c8fd2dcdff37a80d8aecaf22492.

Reason: see https://github.com/tailscale/wireguard-go/pull/76#issuecomment-4802976368
