### PR TITLE
tools: replace CODEOWNERS with palantir/policy-bot

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -1,0 +1,50 @@
+# Approval policy for this repository, enforced by policy-bot
+# (https://github.com/palantir/policy-bot) running at
+# https://policybot.corp.ts.net.
+#
+# This file replaces the role GitHub's CODEOWNERS played: when a pull
+# request touches a path covered by a rule below, policy-bot posts a
+# status check that blocks merging until the required reviewers approve.
+#
+# Policy and rule syntax reference:
+#   https://github.com/palantir/policy-bot/blob/develop/README.md
+# Example policy files (team-approval, disapproval, remote, etc.):
+#   https://github.com/palantir/policy-bot/tree/develop/config/policy-examples
+#
+# Do not add to this policy without wide discussion.
+# See https://github.com/tailscale/corp/issues/13972.
+
+policy:
+  approval:
+    - or:
+        - dataplane
+        - overridden
+
+approval_rules:
+  - name: dataplane
+    description: Dataplane can approve.
+    requires:
+      count: 1
+      teams:
+        - "tailscale/dataplane"
+
+  - name: overridden
+    description: |
+      Any member of @tailscale/dev (other than the PR author) can
+      override the control-protocol-owners requirement by leaving a
+      comment of the form
+
+          policybot-override: <reason>
+
+      on the pull request. The reason can be anything but should
+      explain why the override is appropriate; it stays in the PR
+      conversation as a record. The override comment also counts as
+      that developer's approval.
+    requires:
+      count: 1
+      teams:
+        - "tailscale/dev"
+    options:
+      methods:
+        comment_patterns:
+          - '^policybot-override: \S.*'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
-# Every file in this repo requires review from the dataplane team.
-* @tailscale/dataplane
+# This repository does NOT use GitHub's CODEOWNERS for review enforcement.
+# Approval policies live in .policy.yml at the repository root and are
+# enforced by policy-bot (https://github.com/palantir/policy-bot).
+#
+# To change required reviewers for a path, edit .policy.yml.
+#
+# See https://github.com/tailscale/corp/issues/13972.


### PR DESCRIPTION
Sets two conditions: approved by @tailscale/dataplane, or overridden with a reason by anyone from @tailscale/dev.

Updates tailscale/corp#13972


Change-Id: Iec8ac47a98a195ae10d4533f4179556c6a6a6964