### PR TITLE
device: implement ScheduleHandshakeOnUserSend

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -580,6 +580,26 @@ func (device *Device) SetPriorityMessageOnEstablishmentFunc(f PeerPriorityMessag
 	device.priorityMsgFn.Store(&f)
 }
 
+// ScheduleHandshakeOnUserSend marks the peer for handshake initiation immediately
+// following its next outbound transport message. It is a no-op if the peer is
+// unknown or currently holds no key material.
+//
+// The initiation remains subject to [RekeyTimeout] elapsing since the last
+// handshake message was sent. A request blocked by that window stays armed for
+// a later transport message rather than being dropped.
+func (device *Device) ScheduleHandshakeOnUserSend(peer NoisePublicKey) {
+	device.peers.RLock()
+	defer device.peers.RUnlock()
+	p, ok := device.peers.keyMap[peer]
+	if !ok {
+		return
+	}
+	if !p.hasKeyMaterial() {
+		return
+	}
+	p.handshakeOnUserSend.Store(true)
+}
+
 func (device *Device) Close() {
 	device.state.Lock()
 	defer device.state.Unlock()

--- a/device/failed_handshake_test.go
+++ b/device/failed_handshake_test.go
@@ -15,7 +15,11 @@ import (
 	"github.com/tailscale/wireguard-go/tun/tuntest"
 )
 
-func newSynctestDevice(tb testing.TB) *Device {
+// newSynctestCapableDevice returns a [Device] that is safe to use within a
+// synctest bubble. It uses channel-based [conn.Bind]s instead of goroutines
+// performing "real" I/O, which can never durably block. The returned [Device]
+// is registered to Close() at tb.Cleanup time.
+func newSynctestCapableDevice(tb testing.TB) *Device {
 	tb.Helper()
 	sk, err := newPrivateKey()
 	if err != nil {
@@ -31,7 +35,7 @@ func newSynctestDevice(tb testing.TB) *Device {
 
 func TestLazyPeerReaping(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		dev := newSynctestDevice(t)
+		dev := newSynctestCapableDevice(t)
 		dev.SetPeerLookupFunc(func(pk NoisePublicKey) (*NewPeerConfig, bool) {
 			ip := netip.AddrFrom4([4]byte{10, pk[0], pk[1], pk[2]})
 			return &NewPeerConfig{AllowedIPs: []netip.Prefix{netip.PrefixFrom(ip, 32)}}, true

--- a/device/handshake_on_send_test.go
+++ b/device/handshake_on_send_test.go
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestScheduleHandshakeOnUserSend(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dev := newSynctestCapableDevice(t)
+		peerKey := NoisePublicKey{1}
+		peer, err := dev.NewPeer(peerKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		synctest.Wait() // peer.Start() must return before we continue, since it mutates lastSentHandshake
+
+		// known peer but no key material yet, flag stays false
+		dev.ScheduleHandshakeOnUserSend(peerKey)
+		if peer.handshakeOnUserSend.Load() {
+			t.Fatal("flag armed without key material")
+		}
+
+		// set some key material, then it should arm
+		peer.keypairs.Lock()
+		peer.keypairs.current = &Keypair{}
+		peer.keypairs.Unlock()
+		dev.ScheduleHandshakeOnUserSend(peerKey)
+		if !peer.handshakeOnUserSend.Load() {
+			t.Fatal("flag not armed despite key material")
+		}
+
+		// a handshake sent at the same time as previous should not clear the flag
+		peer.handshake.mutex.Lock()
+		peer.handshake.lastSentHandshake = time.Now()
+		peer.handshake.mutex.Unlock()
+		_ = peer.SendHandshakeInitiation(false)
+		if !peer.handshakeOnUserSend.Load() {
+			t.Fatal("flag cleared while inside RekeyTimeout window")
+		}
+
+		// advance clock by RekeyTimeout
+		time.Sleep(RekeyTimeout)
+
+		// we are now outside the RekeyTimeout window, the flag should clear
+		_ = peer.SendHandshakeInitiation(false)
+		if peer.handshakeOnUserSend.Load() {
+			t.Fatal("flag not cleared after outside RekeyTimeout window")
+		}
+
+		// advance clock by RekeyTimeout and capture bubble wall clock
+		time.Sleep(RekeyTimeout)
+		now := time.Now()
+
+		// this should not trigger a new handshake as:
+		//  a. handshakeOnUserSend is unarmed
+		//  b. nonce is not exhausted
+		//  c. peer is not initiator
+		peer.keepKeyFreshSending()
+		peer.handshake.mutex.Lock()
+		lastHandshake := peer.handshake.lastSentHandshake
+		peer.handshake.mutex.Unlock()
+		if lastHandshake.Equal(now) {
+			t.Fatal("unexpected handshake sent around keepKeyFreshSending")
+		}
+
+		// arm the flag and try again, a handshake should fire
+		dev.ScheduleHandshakeOnUserSend(peerKey)
+		peer.keepKeyFreshSending()
+		peer.handshake.mutex.Lock()
+		lastHandshake = peer.handshake.lastSentHandshake
+		peer.handshake.mutex.Unlock()
+		if !lastHandshake.Equal(now) {
+			t.Fatal("expected handshake sent around keepKeyFreshSending")
+		}
+	})
+}

--- a/device/peer.go
+++ b/device/peer.go
@@ -18,14 +18,15 @@ import (
 )
 
 type Peer struct {
-	isRunning         atomic.Bool
-	keypairs          Keypairs
-	handshake         Handshake
-	device            *Device
-	stopping          sync.WaitGroup // routines pending stop
-	txBytes           atomic.Uint64  // bytes send to peer (endpoint)
-	rxBytes           atomic.Uint64  // bytes received from peer
-	lastHandshakeNano atomic.Int64   // nano seconds since epoch
+	isRunning           atomic.Bool
+	keypairs            Keypairs
+	handshake           Handshake
+	device              *Device
+	stopping            sync.WaitGroup // routines pending stop
+	txBytes             atomic.Uint64  // bytes send to peer (endpoint)
+	rxBytes             atomic.Uint64  // bytes received from peer
+	lastHandshakeNano   atomic.Int64   // nanoseconds since epoch
+	handshakeOnUserSend atomic.Bool    // attempt handshake following next outbound transport
 
 	sessionState struct {
 		sync.Mutex

--- a/device/send.go
+++ b/device/send.go
@@ -186,6 +186,10 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 		peer.handshake.mutex.Unlock()
 		return nil
 	}
+	// handshakeOnUserSend is flipped false after lastSentHandshake checks,
+	// enabling eventual transmission at a future call of this method, while
+	// still honoring [RekeyTimeout].
+	peer.handshakeOnUserSend.Store(false)
 	peer.handshake.lastSentHandshake = time.Now()
 	peer.handshake.mutex.Unlock()
 
@@ -274,8 +278,9 @@ func (peer *Peer) keepKeyFreshSending() {
 	if keypair == nil {
 		return
 	}
+	txHandshake := peer.handshakeOnUserSend.Load()
 	nonce := keypair.sendNonce.Load()
-	if nonce > RekeyAfterMessages || (keypair.isInitiator && time.Since(keypair.created) > RekeyAfterTime) {
+	if txHandshake || nonce > RekeyAfterMessages || (keypair.isInitiator && time.Since(keypair.created) > RekeyAfterTime) {
 		peer.SendHandshakeInitiation(false)
 	}
 }


### PR DESCRIPTION
To enable faster recovery around remote peer restarts, which we get signals about out-of-band. The previous tailscale/tailscale method completely tore down and reconfigured peers, which could disrupt active sessions dependent on timing of restart signals.

Updates tailscale/tailscale#20590