### PR TITLE
tun: fix unaligned int32 reads in getIFIndex and getMTU

### DIFF
--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -9,6 +9,7 @@ package tun
  */
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -249,7 +250,7 @@ func getIFIndex(name string) (int32, error) {
 		return 0, errno
 	}
 
-	return *(*int32)(unsafe.Pointer(&ifr[unix.IFNAMSIZ])), nil
+	return int32(binary.LittleEndian.Uint32(ifr[unix.IFNAMSIZ : unix.IFNAMSIZ+4])), nil
 }
 
 func (tun *NativeTun) setMTU(n int) error {
@@ -314,7 +315,7 @@ func (tun *NativeTun) MTU() (int, error) {
 		return 0, fmt.Errorf("failed to get MTU of TUN device: %w", errno)
 	}
 
-	return int(*(*int32)(unsafe.Pointer(&ifr[unix.IFNAMSIZ]))), nil
+	return int(binary.LittleEndian.Uint32(ifr[unix.IFNAMSIZ : unix.IFNAMSIZ+4])), nil
 }
 
 func (tun *NativeTun) Name() (string, error) {


### PR DESCRIPTION
getIFIndex and getMTU read the ioctl result (ifr_ifindex, ifr_mtu) from a byte buffer using an unsafe cast: *(*int32)(unsafe.Pointer(&ifr[unix.IFNAMSIZ])). A byte array only requires 1-byte alignment, so the compiler is free to place it at any stack offset. On strict-alignment architectures such as MIPS32, the resulting word load can land at a 3-mod-4 address and raise SIGBUS.

The fault is deterministic per build because the frame layout is fixed at compile time. A mipsel build that places ifr at sp+35 makes the load hit sp+51, which MIPS32 cannot execute. This was reproduced with the official tailscale 1.78.1 mipsel binary as well: tailscaled crashes at TUN creation in getIFIndex.

This is the same class of bug previously fixed for setMTU in commit 4e883d3, which converted that path to the x/sys/unix Ifreq helpers.

The fix reads the values byte-wise with binary.LittleEndian, which is alignment-safe on every architecture and produces identical results. Verified by cross-compiling for linux/mipsle (softfloat) and running under qemu-system-mipsel: the fixed binary creates the TUN device and starts the WireGuard engine, while the unpatched build faults at the same instruction.

Assisted by Hermes
