### PR TITLE
device: fix memory leak in mkIPInCIDRsTestFunc

### DIFF
--- a/device/allowedips.go
+++ b/device/allowedips.go
@@ -426,9 +426,6 @@ func (peer *Peer) AllowedPeerSourceIP(src netip.Addr) bool {
 	return false
 }
 
-// fakePeer is a zero Peer used only as a placeholder in tries used by mkIPInCIDRsTestFunc.
-var fakePeer Peer
-
 // mkIPInCIDRsTestFunc returns a function that tests whether an IP address is
 // contained in any of the given CIDRs.
 func mkIPInCIDRsTestFunc(cidrs []netip.Prefix) func(netip.Addr) bool {
@@ -451,17 +448,20 @@ func mkIPInCIDRsTestFunc(cidrs []netip.Prefix) func(netip.Addr) bool {
 			return false
 		}
 	}
-	// Make a trie for faster lookups. We use a dummy Peer.
+	// Make a trie for faster lookups. Use a local dummy Peer so its
+	// trieEntries and the whole trie can be collected once the returned
+	// closure is gone.
+	fakePeer := new(Peer)
 	var a AllowedIPs
 	for _, c := range cidrs {
-		a.Insert(c, &fakePeer)
+		a.Insert(c, fakePeer)
 	}
 	return func(addr netip.Addr) bool {
 		switch {
 		case addr.Is4():
-			return a.ipv4.lookup4(addr.As4()) == &fakePeer
+			return a.ipv4.lookup4(addr.As4()) == fakePeer
 		default:
-			return a.ipv6.lookup6(addr.As16()) == &fakePeer
+			return a.ipv6.lookup6(addr.As16()) == fakePeer
 		}
 	}
 }

--- a/device/allowedips_test.go
+++ b/device/allowedips_test.go
@@ -6,9 +6,11 @@
 package device
 
 import (
+	"fmt"
 	"math/rand"
 	"net"
 	"net/netip"
+	"runtime"
 	"testing"
 )
 
@@ -244,4 +246,43 @@ func TestTrieIPv6(t *testing.T) {
 	assertEQ(h, 0x24046800, 0x40040800, 0, 0)
 	assertEQ(h, 0x24046800, 0x40040800, 0x10101010, 0x10101010)
 	assertEQ(a, 0x24046800, 0x40040800, 0xdeadbeef, 0xdeadbeef)
+}
+
+// TestMkIPInCIDRsTestFuncNoLeak ensures mkIPInCIDRsTestFunc does not retain the
+// tries it builds after the returned closure is dropped. If the placeholder
+// Peer is shared across calls, every trie node stays threaded onto its
+// trieEntries list and can never be collected, so live heap objects grow with
+// each call.
+func TestMkIPInCIDRsTestFuncNoLeak(t *testing.T) {
+	// Enough CIDRs to force the trie path (>4).
+	cidrs := make([]netip.Prefix, 0, 16)
+	for i := 0; i < 16; i++ {
+		cidrs = append(cidrs, netip.MustParsePrefix(fmt.Sprintf("10.%d.0.0/16", i)))
+	}
+
+	liveObjects := func() uint64 {
+		var m runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&m)
+		return m.HeapObjects
+	}
+
+	// Warm up so allocator/runtime steady state is reached before measuring.
+	for i := 0; i < 100; i++ {
+		_ = mkIPInCIDRsTestFunc(cidrs)
+	}
+	before := liveObjects()
+
+	const iterations = 10000
+	for i := 0; i < iterations; i++ {
+		_ = mkIPInCIDRsTestFunc(cidrs)
+	}
+	after := liveObjects()
+
+	// Each leaked call retains all its trie nodes, so growth would be on the
+	// order of iterations*len(cidrs) objects. A small fixed slack absorbs
+	// unrelated runtime allocations.
+	if growth := int64(after) - int64(before); growth > 1000 {
+		t.Errorf("live heap objects grew by %d across %d calls; trie nodes are being retained", growth, iterations)
+	}
 }


### PR DESCRIPTION
fakePeer was a package-level Peer shared across all calls. AllowedIPs.Insert appends each trie node to node.peer.trieEntries, so every call that built a trie left its nodes attached to the global peer's list. The local AllowedIPs went out of scope, but the trieEntries references kept every node from every call reachable, so they were never collected.

Use a local Peer instead, so its trieEntries and the whole trie are freed once the returned closure is no longer referenced.

Add TestMkIPInCIDRsTestFuncNoLeak, which builds many tries, drops each closure, and asserts that live heap objects do not grow. It fails against the shared-peer version and passes with the fix.

Fixes tailscale/corp#47010