### PR TITLE
device: add const for AllowedIPs linear search max

### DIFF
--- a/device/allowedips.go
+++ b/device/allowedips.go
@@ -426,6 +426,10 @@ func (peer *Peer) AllowedPeerSourceIP(src netip.Addr) bool {
 	return false
 }
 
+// cidrLinearSearchMax is the largest number of CIDRs for which
+// mkIPInCIDRsTestFunc does a linear search instead of building a trie.
+const cidrLinearSearchMax = 4
+
 // mkIPInCIDRsTestFunc returns a function that tests whether an IP address is
 // contained in any of the given CIDRs.
 func mkIPInCIDRsTestFunc(cidrs []netip.Prefix) func(netip.Addr) bool {
@@ -435,7 +439,7 @@ func mkIPInCIDRsTestFunc(cidrs []netip.Prefix) func(netip.Addr) bool {
 	if len(cidrs) == 1 {
 		return func(addr netip.Addr) bool { return cidrs[0].Contains(addr) }
 	}
-	if len(cidrs) <= 4 {
+	if len(cidrs) <= cidrLinearSearchMax {
 		// For small numbers of CIDRs, just do a linear search. The trie construction
 		// is more expensive than the linear search, and the test function is faster
 		// than the trie lookup, so this is a net win.

--- a/device/allowedips_test.go
+++ b/device/allowedips_test.go
@@ -254,10 +254,15 @@ func TestTrieIPv6(t *testing.T) {
 // trieEntries list and can never be collected, so live heap objects grow with
 // each call.
 func TestMkIPInCIDRsTestFuncNoLeak(t *testing.T) {
-	// Enough CIDRs to force the trie path (>4).
-	cidrs := make([]netip.Prefix, 0, 16)
-	for i := 0; i < 16; i++ {
-		cidrs = append(cidrs, netip.MustParsePrefix(fmt.Sprintf("10.%d.0.0/16", i)))
+	// One more than the linear-search max forces the trie path.
+	n := cidrLinearSearchMax + 1
+	if n > 1<<16 {
+		// The 10.a.b.0/24 scheme below only has 2^16 distinct prefixes.
+		t.Fatalf("n=%d exceeds the 2^16 prefixes this test can generate", n)
+	}
+	cidrs := make([]netip.Prefix, 0, n)
+	for i := 0; i < n; i++ {
+		cidrs = append(cidrs, netip.MustParsePrefix(fmt.Sprintf("10.%d.%d.0/24", i/256, i%256)))
 	}
 
 	liveObjects := func() uint64 {


### PR DESCRIPTION
Adds a constant for the largest number of CIDRs for which mkIPInCIDRsTestFunc does a linear search instead of building a trie. The constant is now used in the code and the recently added mem leak regression test.

Updates tailscale/corp#47010