### PR TITLE
conn,device,tun: use single ~128KiB packet buf for batched i/o

### DIFF
--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"runtime"
@@ -202,12 +203,17 @@ again:
 	return fns, uint16(port), nil
 }
 
-func (s *StdNetBind) putMessages(msgs *[]ipv6.Message) {
-	for i := range *msgs {
-		// Non coalesced write paths access only batch.msgs[i].Buffers[0],
-		// but we append more during [coalesceMessages].
-		// Leave index zero accessible:
-		(*msgs)[i] = ipv6.Message{Buffers: (*msgs)[i].Buffers[:1], OOB: (*msgs)[i].OOB}
+// putMessages resets each message in (*msgs)[:usedMsgs] for reuse, then returns
+// msgs to its [sync.Pool].
+func (s *StdNetBind) putMessages(msgs *[]ipv6.Message, usedMsgs int) {
+	for i := range (*msgs)[:usedMsgs] {
+		// Clear references to previously used packet buffers, otherwise they
+		// may never be GC'd.
+		clear((*msgs)[i].Buffers)
+		(*msgs)[i] = ipv6.Message{
+			Buffers: (*msgs)[i].Buffers[:1], // Non-coalesced write paths require a single element.
+			OOB:     (*msgs)[i].OOB,
+		}
 	}
 	s.msgsPool.Put(msgs)
 }
@@ -229,69 +235,62 @@ type batchWriter interface {
 	WriteBatch([]ipv6.Message, int) (int, error)
 }
 
+const maxDatagramSize = 1<<16 - 1
+
 func (s *StdNetBind) receiveIP(
 	br batchReader,
 	conn *net.UDPConn,
 	rxOffload bool,
-	bufs [][]byte,
-	sizes []int,
-	eps []Endpoint,
+	slab []byte,
+	packets []ReceivedPacket,
 ) (n int, err error) {
 	msgs := s.getMessages()
-	for i := range bufs {
-		(*msgs)[i].Buffers[0] = bufs[i]
-		(*msgs)[i].OOB = (*msgs)[i].OOB[:cap((*msgs)[i].OOB)]
+	usedMsgs := 1
+	if runtime.GOOS == "linux" {
+		// set a floor of 1 in case len(slab) < maxDatagramSize
+		usedMsgs = max(1, len(slab)/maxDatagramSize)
+		// we can't read more datagrams than what we can describe in packets
+		usedMsgs = min(len(packets), usedMsgs)
 	}
-	defer s.putMessages(msgs)
+	defer s.putMessages(msgs, usedMsgs)
 	var numMsgs int
 	if runtime.GOOS == "linux" {
-		if rxOffload {
-			readAt := len(*msgs) - 2
-			numMsgs, err = br.ReadBatch((*msgs)[readAt:], 0)
-			if err != nil {
-				return 0, err
+		rem := slab
+		for i := range usedMsgs {
+			end := maxDatagramSize
+			if len(rem) < maxDatagramSize {
+				end = len(rem)
 			}
-			numMsgs, err = splitCoalescedMessages(*msgs, readAt, getGSOSize)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			numMsgs, err = br.ReadBatch(*msgs, 0)
-			if err != nil {
-				return 0, err
-			}
+			(*msgs)[i].Buffers[0] = rem[:end]
+			(*msgs)[i].OOB = (*msgs)[i].OOB[:cap((*msgs)[i].OOB)]
+			rem = rem[end:]
+		}
+		numMsgs, err = br.ReadBatch((*msgs)[:usedMsgs], 0)
+		if err != nil {
+			return 0, err
 		}
 	} else {
 		msg := &(*msgs)[0]
+		msg.Buffers[0] = slab
+		msg.OOB = msg.OOB[:cap(msg.OOB)]
 		msg.N, msg.NN, _, msg.Addr, err = conn.ReadMsgUDP(msg.Buffers[0], msg.OOB)
 		if err != nil {
 			return 0, err
 		}
 		numMsgs = 1
 	}
-	for i := 0; i < numMsgs; i++ {
-		msg := &(*msgs)[i]
-		sizes[i] = msg.N
-		if sizes[i] == 0 {
-			continue
-		}
-		addrPort := msg.Addr.(*net.UDPAddr).AddrPort()
-		ep := &StdNetEndpoint{AddrPort: addrPort} // TODO: remove allocation
-		getSrcFromControl(msg.OOB[:msg.NN], ep)
-		eps[i] = ep
-	}
-	return numMsgs, nil
+	return fillReceivedPackets((*msgs)[:numMsgs], maxDatagramSize, packets, rxOffload, getGSOSize)
 }
 
 func (s *StdNetBind) makeReceiveIPv4(pc *ipv4.PacketConn, conn *net.UDPConn, rxOffload bool) ReceiveFunc {
-	return func(bufs [][]byte, sizes []int, eps []Endpoint) (n int, err error) {
-		return s.receiveIP(pc, conn, rxOffload, bufs, sizes, eps)
+	return func(slab []byte, packets []ReceivedPacket) (n int, err error) {
+		return s.receiveIP(pc, conn, rxOffload, slab, packets)
 	}
 }
 
 func (s *StdNetBind) makeReceiveIPv6(pc *ipv6.PacketConn, conn *net.UDPConn, rxOffload bool) ReceiveFunc {
-	return func(bufs [][]byte, sizes []int, eps []Endpoint) (n int, err error) {
-		return s.receiveIP(pc, conn, rxOffload, bufs, sizes, eps)
+	return func(slab []byte, packets []ReceivedPacket) (n int, err error) {
+		return s.receiveIP(pc, conn, rxOffload, slab, packets)
 	}
 }
 
@@ -368,7 +367,8 @@ func (s *StdNetBind) Send(bufs [][]byte, endpoint Endpoint, offset int) error {
 	}
 
 	msgs := s.getMessages()
-	defer s.putMessages(msgs)
+	usedMsgs := len(bufs)
+	defer s.putMessages(msgs, usedMsgs)
 	ua := s.udpAddrPool.Get().(*net.UDPAddr)
 	defer s.udpAddrPool.Put(ua)
 	if is6 {
@@ -524,45 +524,41 @@ func coalesceMessages(addr *net.UDPAddr, ep *StdNetEndpoint, bufs [][]byte, offs
 
 type getGSOFunc func(control []byte) (int, error)
 
-func splitCoalescedMessages(msgs []ipv6.Message, firstMsgAt int, getGSO getGSOFunc) (n int, err error) {
-	for i := firstMsgAt; i < len(msgs); i++ {
-		msg := &msgs[i]
-		if msg.N == 0 {
-			return n, err
-		}
+func fillReceivedPackets(msgs []ipv6.Message, slabOffset int, packets []ReceivedPacket, rxOffload bool, getGSO getGSOFunc) (n int, err error) {
+	for i, msg := range msgs {
 		var (
 			gsoSize    int
 			start      int
-			end        = msg.N
 			numToSplit = 1
 		)
-		gsoSize, err = getGSO(msg.OOB[:msg.NN])
-		if err != nil {
-			return n, err
-		}
-		if gsoSize > 0 {
-			numToSplit = (msg.N + gsoSize - 1) / gsoSize
-			end = gsoSize
-		}
-		for j := 0; j < numToSplit; j++ {
-			if n > i {
-				return n, errors.New("splitting coalesced packet resulted in overflow")
+		if rxOffload {
+			gsoSize, err = getGSO(msg.OOB[:msg.NN])
+			if err != nil {
+				return n, err
 			}
-			copied := copy(msgs[n].Buffers[0], msg.Buffers[0][start:end])
-			msgs[n].N = copied
-			msgs[n].Addr = msg.Addr
-			start = end
-			end += gsoSize
-			if end > msg.N {
-				end = msg.N
+			if gsoSize > 0 {
+				numToSplit = (msg.N + gsoSize - 1) / gsoSize
+			}
+		}
+		addrPort := msg.Addr.(*net.UDPAddr).AddrPort()
+		ep := &StdNetEndpoint{AddrPort: addrPort} // TODO: remove allocation
+		getSrcFromControl(msg.OOB[:msg.NN], ep)
+		regionOffset := i * slabOffset // region may contain multiple coalesced packets
+		for j := 0; j < numToSplit; j++ {
+			if n >= len(packets) {
+				return n, fmt.Errorf("%w: filling received packet metadata resulted in overflow", io.ErrShortBuffer)
+			}
+			end := msg.N
+			if gsoSize > 0 && start+gsoSize < end {
+				end = start + gsoSize
+			}
+			packets[n] = ReceivedPacket{
+				Offset:   regionOffset + start,
+				Size:     end - start,
+				Endpoint: ep,
 			}
 			n++
-		}
-		if i != n-1 {
-			// It is legal for bytes to move within msg.Buffers[0] as a result
-			// of splitting, so we only zero the source msg len when it is not
-			// the destination of the last split operation above.
-			msg.N = 0
+			start = end
 		}
 	}
 	return n, nil

--- a/conn/bind_std_test.go
+++ b/conn/bind_std_test.go
@@ -15,15 +15,13 @@ func TestStdNetBindReceiveFuncAfterClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	bind.Close()
-	bufs := make([][]byte, 1)
-	bufs[0] = make([]byte, 1)
-	sizes := make([]int, 1)
-	eps := make([]Endpoint, 1)
+	slab := make([]byte, 1)
+	packets := make([]ReceivedPacket, 1)
 	for _, fn := range fns {
 		// The ReceiveFuncs must not access conn-related fields on StdNetBind
 		// unguarded. Close() nils the conn-related fields resulting in a panic
 		// if they violate the mutex.
-		fn(bufs, sizes, eps)
+		fn(slab, packets)
 	}
 }
 
@@ -136,12 +134,13 @@ func mockGetGSOSize(control []byte) (int, error) {
 	return int(binary.LittleEndian.Uint16(control)), nil
 }
 
-func Test_splitCoalescedMessages(t *testing.T) {
+func Test_fillReceivedPackets(t *testing.T) {
 	newMsg := func(n, gso int) ipv6.Message {
 		msg := ipv6.Message{
-			Buffers: [][]byte{make([]byte, 1<<16-1)},
+			Buffers: [][]byte{make([]byte, maxDatagramSize)},
 			N:       n,
 			OOB:     make([]byte, 2),
+			Addr:    &net.UDPAddr{},
 		}
 		binary.LittleEndian.PutUint16(msg.OOB, uint16(gso))
 		if gso > 0 {
@@ -153,103 +152,120 @@ func Test_splitCoalescedMessages(t *testing.T) {
 	cases := []struct {
 		name        string
 		msgs        []ipv6.Message
-		firstMsgAt  int
 		wantNumEval int
-		wantMsgLens []int
+		wantPackets [][2]int // {offset, size}
 		wantErr     bool
 	}{
 		{
-			name: "second last split last empty",
+			name: "first split",
 			msgs: []ipv6.Message{
-				newMsg(0, 0),
-				newMsg(0, 0),
 				newMsg(3, 1),
-				newMsg(0, 0),
 			},
-			firstMsgAt:  2,
 			wantNumEval: 3,
-			wantMsgLens: []int{1, 1, 1, 0},
-			wantErr:     false,
+			wantPackets: [][2]int{
+				{0, 1},
+				{1, 1},
+				{2, 1},
+			},
+			wantErr: false,
 		},
 		{
-			name: "second last no split last empty",
+			name: "first no split",
 			msgs: []ipv6.Message{
-				newMsg(0, 0),
-				newMsg(0, 0),
 				newMsg(1, 0),
-				newMsg(0, 0),
 			},
-			firstMsgAt:  2,
 			wantNumEval: 1,
-			wantMsgLens: []int{1, 0, 0, 0},
-			wantErr:     false,
+			wantPackets: [][2]int{
+				{0, 1},
+			},
+			wantErr: false,
 		},
 		{
-			name: "second last no split last no split",
+			name: "first no split last no split",
 			msgs: []ipv6.Message{
-				newMsg(0, 0),
-				newMsg(0, 0),
 				newMsg(1, 0),
 				newMsg(1, 0),
 			},
-			firstMsgAt:  2,
 			wantNumEval: 2,
-			wantMsgLens: []int{1, 1, 0, 0},
-			wantErr:     false,
+			wantPackets: [][2]int{
+				{0, 1},
+				{maxDatagramSize, 1},
+			},
+			wantErr: false,
 		},
 		{
-			name: "second last no split last split",
+			name: "first no split last split",
 			msgs: []ipv6.Message{
-				newMsg(0, 0),
-				newMsg(0, 0),
 				newMsg(1, 0),
 				newMsg(3, 1),
 			},
-			firstMsgAt:  2,
 			wantNumEval: 4,
-			wantMsgLens: []int{1, 1, 1, 1},
-			wantErr:     false,
+			wantPackets: [][2]int{
+				{0, 1},
+				{maxDatagramSize, 1},
+				{maxDatagramSize + 1, 1},
+				{maxDatagramSize + 2, 1},
+			},
+			wantErr: false,
 		},
 		{
-			name: "second last split last split",
+			name: "first split last split",
 			msgs: []ipv6.Message{
-				newMsg(0, 0),
-				newMsg(0, 0),
 				newMsg(2, 1),
 				newMsg(2, 1),
 			},
-			firstMsgAt:  2,
 			wantNumEval: 4,
-			wantMsgLens: []int{1, 1, 1, 1},
-			wantErr:     false,
+			wantPackets: [][2]int{
+				{0, 1},
+				{1, 1},
+				{maxDatagramSize, 1},
+				{maxDatagramSize + 1, 1},
+			},
+			wantErr: false,
 		},
 		{
-			name: "second last no split last split overflow",
+			name: "first no split last split overflow",
 			msgs: []ipv6.Message{
-				newMsg(0, 0),
-				newMsg(0, 0),
 				newMsg(1, 0),
 				newMsg(4, 1),
 			},
-			firstMsgAt:  2,
 			wantNumEval: 4,
-			wantMsgLens: []int{1, 1, 1, 1},
-			wantErr:     true,
+			wantPackets: [][2]int{
+				{0, 1},
+				{maxDatagramSize, 1},
+				{maxDatagramSize + 1, 1},
+				{maxDatagramSize + 2, 1},
+			},
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := splitCoalescedMessages(tt.msgs, 2, mockGetGSOSize)
-			if err != nil && !tt.wantErr {
+			packets := make([]ReceivedPacket, len(tt.wantPackets))
+			got, err := fillReceivedPackets(
+				tt.msgs,
+				1<<16-1,
+				packets,
+				true,
+				mockGetGSOSize,
+			)
+			if (err != nil) != tt.wantErr {
 				t.Fatalf("err: %v", err)
 			}
 			if got != tt.wantNumEval {
 				t.Fatalf("got to eval: %d want: %d", got, tt.wantNumEval)
 			}
-			for i, msg := range tt.msgs {
-				if msg.N != tt.wantMsgLens[i] {
-					t.Fatalf("msg[%d].N: %d want: %d", i, msg.N, tt.wantMsgLens[i])
+			if len(packets) != len(tt.wantPackets) {
+				t.Fatalf("got %d packets, want %d", len(packets), len(tt.wantPackets))
+			}
+			for i, want := range tt.wantPackets {
+				got := packets[i]
+				if got.Offset != want[0] || got.Size != want[1] {
+					t.Errorf(
+						"packets[%d] = {Offset: %d, Size: %d}, want {Offset: %d, Size: %d}",
+						i, got.Offset, got.Size, want[0], want[1],
+					)
 				}
 			}
 		})

--- a/conn/bind_windows.go
+++ b/conn/bind_windows.go
@@ -416,21 +416,25 @@ retry:
 	return n, &ep, nil
 }
 
-func (bind *WinRingBind) receiveIPv4(bufs [][]byte, sizes []int, eps []Endpoint) (int, error) {
+func (bind *WinRingBind) receiveIPv4(slab []byte, packets []ReceivedPacket) (int, error) {
 	bind.mu.RLock()
 	defer bind.mu.RUnlock()
-	n, ep, err := bind.v4.Receive(bufs[0], &bind.isOpen)
-	sizes[0] = n
-	eps[0] = ep
+	n, ep, err := bind.v4.Receive(slab, &bind.isOpen)
+	packets[0] = ReceivedPacket{
+		Size:     n,
+		Endpoint: ep,
+	}
 	return 1, err
 }
 
-func (bind *WinRingBind) receiveIPv6(bufs [][]byte, sizes []int, eps []Endpoint) (int, error) {
+func (bind *WinRingBind) receiveIPv6(slab []byte, packets []ReceivedPacket) (int, error) {
 	bind.mu.RLock()
 	defer bind.mu.RUnlock()
-	n, ep, err := bind.v6.Receive(bufs[0], &bind.isOpen)
-	sizes[0] = n
-	eps[0] = ep
+	n, ep, err := bind.v6.Receive(slab, &bind.isOpen)
+	packets[0] = ReceivedPacket{
+		Size:     n,
+		Endpoint: ep,
+	}
 	return 1, err
 }
 

--- a/conn/bindtest/bindtest.go
+++ b/conn/bindtest/bindtest.go
@@ -94,14 +94,16 @@ func (c *ChannelBind) BatchSize() int { return 1 }
 func (c *ChannelBind) SetMark(mark uint32) error { return nil }
 
 func (c *ChannelBind) makeReceiveFunc(ch chan []byte) conn.ReceiveFunc {
-	return func(bufs [][]byte, sizes []int, eps []conn.Endpoint) (n int, err error) {
+	return func(slab []byte, packets []conn.ReceivedPacket) (n int, err error) {
 		select {
 		case <-c.closeSignal:
 			return 0, net.ErrClosed
 		case rx := <-ch:
-			copied := copy(bufs[0], rx)
-			sizes[0] = copied
-			eps[0] = c.target6
+			copied := copy(slab, rx)
+			packets[0] = conn.ReceivedPacket{
+				Size:     copied,
+				Endpoint: c.target6,
+			}
 			return 1, nil
 		}
 	}

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -19,13 +19,25 @@ const (
 	IdealBatchSize = 128 // maximum number of packets handled per read and write
 )
 
+// ReceivedPacket describes a packet read by a [ReceiveFunc].
+type ReceivedPacket struct {
+	// Offset is the starting byte offset.
+	Offset int
+	// Size is the size of the packet.
+	Size int
+	// Endpoint is the associated [Endpoint].
+	Endpoint Endpoint
+}
+
+func (r *ReceivedPacket) Bytes(slab []byte) []byte {
+	return slab[r.Offset : r.Offset+r.Size : r.Offset+r.Size]
+}
+
 // A ReceiveFunc receives at least one packet from the network and writes them
-// into packets. On a successful read it returns the number of elements of
-// sizes, packets, and endpoints that should be evaluated. Some elements of
-// sizes may be zero, and callers should ignore them. Callers must pass a sizes
-// and eps slice with a length greater than or equal to the length of packets.
-// These lengths must not exceed the length of the associated Bind.BatchSize().
-type ReceiveFunc func(packets [][]byte, sizes []int, eps []Endpoint) (n int, err error)
+// into slab. On a successful read it returns the number of elements of
+// packets that should be evaluated. Callers must pass a length of packets equal
+// to the associated [Bind.BatchSize].
+type ReceiveFunc func(slab []byte, packets []ReceivedPacket) (n int, err error)
 
 // A Bind listens on a port for both IPv6 and IPv4 UDP traffic.
 //

--- a/conn/conn_test.go
+++ b/conn/conn_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPrettyName(t *testing.T) {
 	var (
-		recvFunc ReceiveFunc = func(bufs [][]byte, sizes []int, eps []Endpoint) (n int, err error) { return }
+		recvFunc ReceiveFunc = func(slab []byte, packets []ReceivedPacket) (n int, err error) { return }
 	)
 
 	const want = "TestPrettyName"

--- a/device/device.go
+++ b/device/device.go
@@ -77,9 +77,9 @@ type Device struct {
 	pool struct {
 		inboundElementsContainer  *WaitPool
 		outboundElementsContainer *WaitPool
-		messageBuffers            *WaitPool
 		inboundElements           *WaitPool
 		outboundElements          *WaitPool
+		packetBufs                *WaitPool
 	}
 
 	queue struct {

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -518,7 +518,7 @@ type fakeTUNDeviceSized struct {
 }
 
 func (t *fakeTUNDeviceSized) File() *os.File { return nil }
-func (t *fakeTUNDeviceSized) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
+func (t *fakeTUNDeviceSized) Read(slab []byte, packets []tun.ReadPacket) (n int, err error) {
 	return 0, nil
 }
 func (t *fakeTUNDeviceSized) Write(bufs [][]byte, offset int) (int, error) { return 0, nil }

--- a/device/packetbuf.go
+++ b/device/packetbuf.go
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/tailscale/wireguard-go/tun"
+	"golang.org/x/crypto/poly1305"
+)
+
+const (
+	outboundPlaintextHeadroom = MessageEncapsulatingTransportSize + MessageTransportHeaderSize
+
+	outboundPlaintextTailroom = PaddingMultiple - 1 + poly1305.TagSize
+
+	outboundPlaintextSpacing = max(outboundPlaintextHeadroom+outboundPlaintextTailroom, tun.ReadPacketSpacing)
+
+	// singlePacketSlabSize is the size to be used for [packetBuf.slab] when
+	// neither [tun.Device] nor [conn.Bind] support batched reads.
+	singlePacketSlabSize = MaxContentSize + 2*tun.ReadPacketSpacing
+
+	// batchingSlabSize is the size to be used for [packetBuf.slab] when either
+	// [tun.Device] or [conn.Bind] support batched reads. This covers the
+	// [tun.GSOSplit] worst case for minimum-sized MTU/MSS, which is documented
+	// in [tun.TestGSOSplitMinimumGSOSize].
+	batchingSlabSize = 2 * (1<<16 - 1)
+)
+
+// The tun package cannot import device, so we assert [tun.ReadPacketSpacing] is
+// greater than or equal to [outboundPlaintextSpacing] instead.
+const _ = uint(tun.ReadPacketSpacing - outboundPlaintextSpacing)
+
+// packetBuf is a reference counted packet buffer.
+type packetBuf struct {
+	slab     []byte
+	refCount atomic.Int32
+	cleanup  func(*packetBuf)
+}
+
+// newPacketBuf returns a new [*packetBuf] of the provided size with its
+// reference count set to zero. cleanup runs for the returned [*packetBuf] when
+// its ref count moves 1->0.
+func newPacketBuf(size int, cleanup func(*packetBuf)) *packetBuf {
+	return &packetBuf{
+		slab:    make([]byte, size),
+		cleanup: cleanup,
+	}
+}
+
+func (p *packetBuf) incRef() {
+	p.refCount.Add(1)
+}
+
+func (p *packetBuf) decRef() {
+	c := p.refCount.Add(-1)
+	if c == 0 {
+		p.cleanup(p)
+	} else if c < 0 {
+		panic(fmt.Sprintf("packetBuf.decRef below zero (%d)", c))
+	}
+}

--- a/device/packetbuf_test.go
+++ b/device/packetbuf_test.go
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestPacketBufRefCount(t *testing.T) {
+	var cleanups atomic.Int32
+	buf := newPacketBuf(0, func(buf *packetBuf) {
+		cleanups.Add(1)
+	})
+	if buf.refCount.Load() != 0 {
+		t.Fatalf("buf.refCount initialized nonzero: %d", buf.refCount.Load())
+	}
+	buf.incRef()
+	buf.incRef()
+	if buf.refCount.Load() != 2 {
+		t.Fatalf("buf.refCount = %d, want 2", buf.refCount.Load())
+	}
+	buf.decRef()
+	if got := cleanups.Load(); got != 0 {
+		t.Fatalf("cleanup count after first decRef = %d, want 0", got)
+	}
+	buf.decRef()
+	if cleanups.Load() != 1 {
+		t.Fatalf("cleanup count = %d, want 1", cleanups.Load())
+	}
+	if got := buf.refCount.Load(); got != 0 {
+		t.Fatalf("final ref count = %d, want 0", got)
+	}
+}
+
+func TestPacketBufRefCountUnderflow(t *testing.T) {
+	var cleanups atomic.Int32
+	buf := newPacketBuf(0, func(*packetBuf) {
+		cleanups.Add(1)
+	})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("decRef did not panic on underflow")
+		}
+		if got := cleanups.Load(); got != 0 {
+			t.Fatalf("cleanup count = %d, want 0", got)
+		}
+	}()
+
+	buf.decRef()
+}
+
+func TestGetPacketBufOwnsReference(t *testing.T) {
+	device := new(Device)
+	device.pool.packetBufs = NewWaitPool(0, func() any {
+		return newPacketBuf(0, func(buf *packetBuf) {
+			device.pool.packetBufs.Put(buf)
+		})
+	})
+
+	buf := device.getPacketBuf()
+	if got := buf.refCount.Load(); got != 1 {
+		t.Fatalf("buf.refCount = %d, want 1", got)
+	}
+	buf.decRef()
+}

--- a/device/peer.go
+++ b/device/peer.go
@@ -350,7 +350,6 @@ func (peer *Peer) queueOutboundIfRunning(elems *QueueOutboundElementsContainer) 
 		peer.device.queue.encryption.c <- elems
 	}); !queued {
 		for _, elem := range elems.elems {
-			peer.device.PutMessageBuffer(elem.buffer)
 			peer.device.PutOutboundElement(elem)
 		}
 		peer.device.PutOutboundElementsContainer(elems)
@@ -368,7 +367,6 @@ func (peer *Peer) queueInboundIfRunning(elems *QueueInboundElementsContainer) (q
 		peer.device.queue.decryption.c <- elems
 	}); !queued {
 		for _, elem := range elems.elems {
-			peer.device.PutMessageBuffer(elem.buffer)
 			peer.device.PutInboundElement(elem)
 		}
 		peer.device.PutInboundElementsContainer(elems)
@@ -413,14 +411,12 @@ func (peer *Peer) waitQueueActors() {
 			case container := <-peer.queue.inbound:
 				container.filling.Wait()
 				for _, elem := range container.elems {
-					peer.device.PutMessageBuffer(elem.buffer)
 					peer.device.PutInboundElement(elem)
 				}
 				peer.device.PutInboundElementsContainer(container)
 			case container := <-peer.queue.outbound:
 				container.filling.Wait()
 				for _, elem := range container.elems {
-					peer.device.PutMessageBuffer(elem.buffer)
 					peer.device.PutOutboundElement(elem)
 				}
 				peer.device.PutOutboundElementsContainer(container)

--- a/device/pools.go
+++ b/device/pools.go
@@ -55,14 +55,20 @@ func (device *Device) PopulatePools() {
 		s := make([]*QueueOutboundElement, 0, device.BatchSize())
 		return &QueueOutboundElementsContainer{elems: s}
 	})
-	device.pool.messageBuffers = NewWaitPool(device.config.preallocatedBuffersPerPool, func() any {
-		return new([MaxMessageSize]byte)
-	})
 	device.pool.inboundElements = NewWaitPool(device.config.preallocatedBuffersPerPool, func() any {
 		return new(QueueInboundElement)
 	})
 	device.pool.outboundElements = NewWaitPool(device.config.preallocatedBuffersPerPool, func() any {
 		return new(QueueOutboundElement)
+	})
+	packetBufSize := singlePacketSlabSize
+	if device.BatchSize() > 1 {
+		packetBufSize = batchingSlabSize
+	}
+	device.pool.packetBufs = NewWaitPool(device.config.preallocatedBuffersPerPool, func() any {
+		return newPacketBuf(packetBufSize, func(buf *packetBuf) {
+			device.pool.packetBufs.Put(buf)
+		})
 	})
 }
 
@@ -92,12 +98,10 @@ func (device *Device) PutOutboundElementsContainer(c *QueueOutboundElementsConta
 	device.pool.outboundElementsContainer.Put(c)
 }
 
-func (device *Device) GetMessageBuffer() *[MaxMessageSize]byte {
-	return device.pool.messageBuffers.Get().(*[MaxMessageSize]byte)
-}
-
-func (device *Device) PutMessageBuffer(msg *[MaxMessageSize]byte) {
-	device.pool.messageBuffers.Put(msg)
+func (device *Device) getPacketBuf() *packetBuf {
+	b := device.pool.packetBufs.Get().(*packetBuf)
+	b.incRef()
+	return b
 }
 
 func (device *Device) GetInboundElement() *QueueInboundElement {
@@ -105,15 +109,25 @@ func (device *Device) GetInboundElement() *QueueInboundElement {
 }
 
 func (device *Device) PutInboundElement(elem *QueueInboundElement) {
+	elem.buffer.decRef()
 	elem.clearPointers()
 	device.pool.inboundElements.Put(elem)
 }
 
+// GetOutboundElement returns a [*QueueOutboundElement] with all its fields
+// set to their respective zero values.
 func (device *Device) GetOutboundElement() *QueueOutboundElement {
-	return device.pool.outboundElements.Get().(*QueueOutboundElement)
+	elem := device.pool.outboundElements.Get().(*QueueOutboundElement)
+	elem.plaintextOffset = 0
+	elem.nonce = 0
+	// buffer, packet, keypair, and peer were cleared (if necessary) by [QueueOutboundElement.clearPointers].
+	return elem
 }
 
 func (device *Device) PutOutboundElement(elem *QueueOutboundElement) {
+	if elem.buffer != nil {
+		elem.buffer.decRef()
+	}
 	elem.clearPointers()
 	device.pool.outboundElements.Put(elem)
 }

--- a/device/receive.go
+++ b/device/receive.go
@@ -21,18 +21,18 @@ import (
 )
 
 type QueueHandshakeElement struct {
-	msgType  uint32
-	packet   []byte
-	endpoint conn.Endpoint
-	buffer   *[MaxMessageSize]byte
+	msgType    uint32
+	packet     []byte
+	packetMeta conn.ReceivedPacket
+	buffer     *packetBuf
 }
 
 type QueueInboundElement struct {
-	buffer   *[MaxMessageSize]byte
-	packet   []byte
-	counter  uint64
-	keypair  *Keypair
-	endpoint conn.Endpoint
+	buffer     *packetBuf
+	packet     []byte
+	packetMeta conn.ReceivedPacket
+	counter    uint64
+	keypair    *Keypair
 }
 
 type QueueInboundElementsContainer struct {
@@ -52,8 +52,8 @@ type QueueInboundElementsContainer struct {
 func (elem *QueueInboundElement) clearPointers() {
 	elem.buffer = nil
 	elem.packet = nil
+	elem.packetMeta = conn.ReceivedPacket{}
 	elem.keypair = nil
-	elem.endpoint = nil
 }
 
 /* Called when a new authenticated message has been received
@@ -90,31 +90,29 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 	// receive datagrams until conn is closed
 
 	var (
-		bufsArrs    = make([]*[MaxMessageSize]byte, maxBatchSize)
-		bufs        = make([][]byte, maxBatchSize)
+		packets = make([]conn.ReceivedPacket, maxBatchSize)
+		buf     = device.getPacketBuf()
+		// bufDirty tracks whether the current buf has been pushed downstream to
+		// crypto and per-peer/handshake functions, or can be re-used across the
+		// next read cycle
+		bufDirty    bool
 		err         error
-		sizes       = make([]int, maxBatchSize)
 		count       int
-		endpoints   = make([]conn.Endpoint, maxBatchSize)
 		deathSpiral int
 		elemsByPeer = make(map[*Peer]*QueueInboundElementsContainer, maxBatchSize)
 	)
 
-	for i := range bufsArrs {
-		bufsArrs[i] = device.GetMessageBuffer()
-		bufs[i] = bufsArrs[i][:]
-	}
-
 	defer func() {
-		for i := 0; i < maxBatchSize; i++ {
-			if bufsArrs[i] != nil {
-				device.PutMessageBuffer(bufsArrs[i])
-			}
-		}
+		buf.decRef()
 	}()
 
 	for {
-		count, err = recv(bufs, sizes, endpoints)
+		if bufDirty {
+			buf.decRef()
+			buf = device.getPacketBuf()
+			bufDirty = false
+		}
+		count, err = recv(buf.slab, packets)
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
 				return
@@ -133,14 +131,14 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 		deathSpiral = 0
 
 		// handle each packet in the batch
-		for i, size := range sizes[:count] {
-			if size < MinMessageSize {
+		for _, meta := range packets[:count] {
+			if meta.Size < MinMessageSize {
 				continue
 			}
 
 			// check size of packet
 
-			packet := bufsArrs[i][:size]
+			packet := meta.Bytes(buf.slab)
 			msgType := binary.LittleEndian.Uint32(packet[:4])
 
 			switch msgType {
@@ -175,10 +173,12 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 				// create work element
 				peer := value.peer
 				elem := device.GetInboundElement()
+				bufDirty = true
+				buf.incRef()
+				elem.buffer = buf
 				elem.packet = packet
-				elem.buffer = bufsArrs[i]
+				elem.packetMeta = meta
 				elem.keypair = keypair
-				elem.endpoint = endpoints[i]
 				elem.counter = 0
 
 				elemsForPeer, ok := elemsByPeer[peer]
@@ -187,8 +187,6 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 					elemsByPeer[peer] = elemsForPeer
 				}
 				elemsForPeer.elems = append(elemsForPeer.elems, elem)
-				bufsArrs[i] = device.GetMessageBuffer()
-				bufs[i] = bufsArrs[i][:]
 				continue
 
 			// otherwise it is a fixed size & handshake related packet
@@ -213,16 +211,17 @@ func (device *Device) RoutineReceiveIncoming(maxBatchSize int, recv conn.Receive
 				continue
 			}
 
+			buf.incRef()
 			select {
 			case device.queue.handshake.c <- QueueHandshakeElement{
-				msgType:  msgType,
-				buffer:   bufsArrs[i],
-				packet:   packet,
-				endpoint: endpoints[i],
+				msgType:    msgType,
+				buffer:     buf,
+				packet:     packet,
+				packetMeta: meta,
 			}:
-				bufsArrs[i] = device.GetMessageBuffer()
-				bufs[i] = bufsArrs[i][:]
+				bufDirty = true
 			default:
+				buf.decRef()
 			}
 		}
 		for peer, elemsContainer := range elemsByPeer {
@@ -300,7 +299,7 @@ func (device *Device) RoutineHandshake(id int) {
 			// consume reply
 
 			if peer := entry.peer; peer.runningState.isRunning.Load() {
-				device.log.Verbosef("Receiving cookie response from %s", elem.endpoint.DstToString())
+				device.log.Verbosef("Receiving cookie response from %s", elem.packetMeta.Endpoint.DstToString())
 				if !peer.cookieGenerator.ConsumeReply(&reply) {
 					device.log.Verbosef("Could not decrypt invalid cookie response")
 				}
@@ -323,14 +322,14 @@ func (device *Device) RoutineHandshake(id int) {
 
 				// verify MAC2 field
 
-				if !device.cookieChecker.CheckMAC2(elem.packet, elem.endpoint.DstToBytes()) {
+				if !device.cookieChecker.CheckMAC2(elem.packet, elem.packetMeta.Endpoint.DstToBytes()) {
 					device.SendHandshakeCookie(&elem)
 					goto skip
 				}
 
 				// check ratelimiter
 
-				if !device.rate.limiter.Allow(elem.endpoint.DstIP()) {
+				if !device.rate.limiter.Allow(elem.packetMeta.Endpoint.DstIP()) {
 					goto skip
 				}
 			}
@@ -356,9 +355,9 @@ func (device *Device) RoutineHandshake(id int) {
 
 			// consume initiation
 
-			peer := device.ConsumeMessageInitiation(&msg, elem.endpoint)
+			peer := device.ConsumeMessageInitiation(&msg, elem.packetMeta.Endpoint)
 			if peer == nil {
-				device.log.Verbosef("Received invalid initiation message from %s", elem.endpoint.DstToString())
+				device.log.Verbosef("Received invalid initiation message from %s", elem.packetMeta.Endpoint.DstToString())
 				goto skip
 			}
 
@@ -387,7 +386,7 @@ func (device *Device) RoutineHandshake(id int) {
 
 			peer := device.ConsumeMessageResponse(&msg)
 			if peer == nil {
-				device.log.Verbosef("Received invalid response message from %s", elem.endpoint.DstToString())
+				device.log.Verbosef("Received invalid response message from %s", elem.packetMeta.Endpoint.DstToString())
 				goto skip
 			}
 
@@ -414,7 +413,7 @@ func (device *Device) RoutineHandshake(id int) {
 			peer.SendKeepalive()
 		}
 	skip:
-		device.PutMessageBuffer(elem.buffer)
+		elem.buffer.decRef()
 	}
 }
 
@@ -478,7 +477,7 @@ func (peer *Peer) processInboundContainer(elemsContainer *QueueInboundElementsCo
 			peer.SendPriorityMessage()
 			peer.SendStagedPackets()
 		}
-		if ep, ok := elem.endpoint.(conn.PeerAwareEndpoint); ok {
+		if ep, ok := elem.packetMeta.Endpoint.(conn.PeerAwareEndpoint); ok {
 			ep.FromPeer(peer.handshake.remoteStatic)
 		}
 		rxBytesLen += uint64(len(elem.packet) + MinMessageSize)
@@ -530,7 +529,8 @@ func (peer *Peer) processInboundContainer(elemsContainer *QueueInboundElementsCo
 			continue
 		}
 
-		scratch = append(scratch, elem.buffer[:MessageTransportOffsetContent+len(elem.packet)])
+		elem.packetMeta.Size = MessageTransportOffsetContent + len(elem.packet)
+		scratch = append(scratch, elem.packetMeta.Bytes(elem.buffer.slab))
 	}
 
 	peer.rxBytes.Add(rxBytesLen)
@@ -549,7 +549,6 @@ func (peer *Peer) processInboundContainer(elemsContainer *QueueInboundElementsCo
 		}
 	}
 	for _, elem := range elems {
-		device.PutMessageBuffer(elem.buffer)
 		device.PutInboundElement(elem)
 	}
 }

--- a/device/send.go
+++ b/device/send.go
@@ -47,15 +47,16 @@ import (
  */
 
 type QueueOutboundElement struct {
-	buffer *[MaxMessageSize]byte // slice holding the packet data
-	// packet is always a slice of "buffer". The starting offset in buffer
-	// is either:
-	//  a) MessageEncapsulatingTransportSize+MessageTransportHeaderSize (plaintext)
-	//  b) 0 (post-encryption)
-	packet  []byte
-	nonce   uint64   // nonce for encryption
-	keypair *Keypair // keypair for encryption
-	peer    *Peer    // related peer
+	buffer *packetBuf // shared packet buffer that contains packet
+	packet []byte     // packet is always a slice of buffer.slab
+	// plaintextOffset describes the pre-encryption offset of packet within
+	// buffer.slab. The encryption process grows packet on both ends to make
+	// room for any potential encapsulating transport, WireGuard header, and
+	// tail padding.
+	plaintextOffset int
+	nonce           uint64   // nonce for encryption
+	keypair         *Keypair // keypair for encryption
+	peer            *Peer    // related peer
 }
 
 type QueueOutboundElementsContainer struct {
@@ -66,14 +67,6 @@ type QueueOutboundElementsContainer struct {
 	// reading the encrypted packets.
 	filling sync.WaitGroup
 	elems   []*QueueOutboundElement
-}
-
-func (device *Device) NewOutboundElement() *QueueOutboundElement {
-	elem := device.GetOutboundElement()
-	elem.buffer = device.GetMessageBuffer()
-	elem.nonce = 0
-	// keypair and peer were cleared (if necessary) by clearPointers.
-	return elem
 }
 
 // clearPointers clears elem fields that contain pointers.
@@ -91,7 +84,9 @@ func (elem *QueueOutboundElement) clearPointers() {
 // peer.
 func (peer *Peer) SendKeepalive() {
 	if len(peer.queue.staged) == 0 {
-		elem := peer.device.NewOutboundElement()
+		elem := peer.device.GetOutboundElement()
+		elem.buffer = peer.device.getPacketBuf() // TODO(jwhited): get a smaller message from a different pool
+		elem.plaintextOffset = MessageEncapsulatingTransportSize + MessageTransportHeaderSize
 		elemsContainer := peer.device.GetOutboundElementsContainer()
 		elemsContainer.elems = append(elemsContainer.elems, elem)
 		if queued := peer.doIfRunning(func() {
@@ -99,12 +94,10 @@ func (peer *Peer) SendKeepalive() {
 			case peer.queue.staged <- elemsContainer:
 				peer.device.log.Verbosef("%v - Sending keepalive packet", peer)
 			default:
-				peer.device.PutMessageBuffer(elem.buffer)
 				peer.device.PutOutboundElement(elem)
 				peer.device.PutOutboundElementsContainer(elemsContainer)
 			}
 		}); !queued {
-			peer.device.PutMessageBuffer(elem.buffer)
 			peer.device.PutOutboundElement(elem)
 			peer.device.PutOutboundElementsContainer(elemsContainer)
 		}
@@ -142,19 +135,22 @@ func (peer *Peer) SendPriorityMessage() {
 	}
 
 	// get pooled elements
-	elem := peer.device.NewOutboundElement()
+	elem := peer.device.GetOutboundElement()
 	elemsContainer := peer.device.GetOutboundElementsContainer()
 	elemsContainer.elems = append(elemsContainer.elems, elem)
+	buf := peer.device.getPacketBuf() // TODO(jwhited): get a smaller message from a different pool
 
 	// initialize outbound element
 	const offset = MessageEncapsulatingTransportSize + MessageTransportHeaderSize
-	n := copy(elem.buffer[offset:], msg)
-	elem.packet = elem.buffer[offset : offset+n]
+
+	n := copy(buf.slab[offset:], msg)
+	elem.buffer = buf
+	elem.packet = buf.slab[offset : offset+n]
+	elem.plaintextOffset = offset
 	elem.peer = peer
 	elem.nonce = keypair.sendNonce.Add(1) - 1
 	if elem.nonce >= RejectAfterMessages {
 		keypair.sendNonce.Store(RejectAfterMessages)
-		peer.device.PutMessageBuffer(elem.buffer)
 		peer.device.PutOutboundElement(elem)
 		peer.device.PutOutboundElementsContainer(elemsContainer)
 		return
@@ -251,10 +247,10 @@ func (peer *Peer) SendHandshakeResponse() error {
 }
 
 func (device *Device) SendHandshakeCookie(initiatingElem *QueueHandshakeElement) error {
-	device.log.Verbosef("Sending cookie response for denied handshake message for %v", initiatingElem.endpoint.DstToString())
+	device.log.Verbosef("Sending cookie response for denied handshake message for %v", initiatingElem.packetMeta.Endpoint.DstToString())
 
 	sender := binary.LittleEndian.Uint32(initiatingElem.packet[4:8])
-	reply, err := device.cookieChecker.CreateReply(initiatingElem.packet, sender, initiatingElem.endpoint.DstToBytes())
+	reply, err := device.cookieChecker.CreateReply(initiatingElem.packet, sender, initiatingElem.packetMeta.Endpoint.DstToBytes())
 	if err != nil {
 		device.log.Errorf("Failed to create cookie reply: %v", err)
 		return err
@@ -264,7 +260,7 @@ func (device *Device) SendHandshakeCookie(initiatingElem *QueueHandshakeElement)
 	packet := buf[MessageEncapsulatingTransportSize:]
 	_ = reply.marshal(packet)
 	// TODO: allocation could be avoided
-	device.net.bind.Send([][]byte{buf}, initiatingElem.endpoint, MessageEncapsulatingTransportSize)
+	device.net.bind.Send([][]byte{buf}, initiatingElem.packetMeta.Endpoint, MessageEncapsulatingTransportSize)
 
 	return nil
 }
@@ -291,59 +287,70 @@ func (device *Device) RoutineReadFromTUN() {
 	device.log.Verbosef("Routine: TUN reader - started")
 
 	var (
-		batchSize   = device.BatchSize()
+		batchSize = device.BatchSize()
+		packets   = make([]tun.ReadPacket, batchSize)
+		buf       = device.getPacketBuf()
+		// bufDirty tracks whether the current buf has been pushed downstream to
+		// crypto and per-peer functions, or can be re-used across read cycles
+		bufDirty    bool
 		readErr     error
 		elems       = make([]*QueueOutboundElement, batchSize)
-		bufs        = make([][]byte, batchSize)
 		elemsByPeer = make(map[*Peer]*QueueOutboundElementsContainer, batchSize)
 		count       = 0
-		sizes       = make([]int, batchSize)
-		offset      = MessageEncapsulatingTransportSize + MessageTransportHeaderSize
 	)
 
+	defer func() {
+		buf.decRef()
+	}()
+
 	for i := range elems {
-		elems[i] = device.NewOutboundElement()
-		bufs[i] = elems[i].buffer[:]
+		elems[i] = device.GetOutboundElement()
 	}
 
 	defer func() {
 		for _, elem := range elems {
 			if elem != nil {
-				device.PutMessageBuffer(elem.buffer)
 				device.PutOutboundElement(elem)
 			}
 		}
 	}()
 
 	for {
+		if bufDirty {
+			buf.decRef()
+			buf = device.getPacketBuf()
+			bufDirty = false
+		}
+
 		// read packets
-		count, readErr = device.tun.device.Read(bufs, sizes, offset)
-		for i := 0; i < count; i++ {
-			if sizes[i] < 1 {
+		count, readErr = device.tun.device.Read(buf.slab, packets)
+		for i, meta := range packets[:count] {
+			if meta.Size < 1 || meta.Size > MaxContentSize {
 				continue
 			}
 
-			elem := elems[i]
-			elem.packet = bufs[i][offset : offset+sizes[i]]
+			// explicitly pin slice capacity, so downstream expansion of length
+			// never leak into an adjacent packet
+			packet := buf.slab[meta.Offset : meta.Offset+meta.Size : meta.Offset+meta.Size+outboundPlaintextTailroom]
 
 			// lookup peer
 			var peer *Peer
-			switch elem.packet[0] >> 4 {
+			switch packet[0] >> 4 {
 			case 4:
-				if len(elem.packet) < ipv4.HeaderLen {
+				if len(packet) < ipv4.HeaderLen {
 					continue
 				}
-				src := netip.AddrFrom4([4]byte(elem.packet[IPv4offsetSrc : IPv4offsetSrc+net.IPv4len]))
-				dst := netip.AddrFrom4([4]byte(elem.packet[IPv4offsetDst : IPv4offsetDst+net.IPv4len]))
-				peer = device.allowedips.LookupFromPacket(src, dst, elem.packet)
+				src := netip.AddrFrom4([4]byte(packet[IPv4offsetSrc : IPv4offsetSrc+net.IPv4len]))
+				dst := netip.AddrFrom4([4]byte(packet[IPv4offsetDst : IPv4offsetDst+net.IPv4len]))
+				peer = device.allowedips.LookupFromPacket(src, dst, packet)
 
 			case 6:
-				if len(elem.packet) < ipv6.HeaderLen {
+				if len(packet) < ipv6.HeaderLen {
 					continue
 				}
-				src := netip.AddrFrom16([16]byte(elem.packet[IPv6offsetSrc : IPv6offsetSrc+net.IPv6len]))
-				dst := netip.AddrFrom16([16]byte(elem.packet[IPv6offsetDst : IPv6offsetDst+net.IPv6len]))
-				peer = device.allowedips.LookupFromPacket(src, dst, elem.packet)
+				src := netip.AddrFrom16([16]byte(packet[IPv6offsetSrc : IPv6offsetSrc+net.IPv6len]))
+				dst := netip.AddrFrom16([16]byte(packet[IPv6offsetDst : IPv6offsetDst+net.IPv6len]))
+				peer = device.allowedips.LookupFromPacket(src, dst, packet)
 
 			default:
 				device.log.Verbosef("Received packet with unknown IP version")
@@ -352,14 +359,21 @@ func (device *Device) RoutineReadFromTUN() {
 			if peer == nil {
 				continue
 			}
+
+			elem := elems[i]
+			buf.incRef()
+			bufDirty = true
+			elem.buffer = buf
+			elem.packet = packet
+			elem.plaintextOffset = meta.Offset
+
 			elemsForPeer, ok := elemsByPeer[peer]
 			if !ok {
 				elemsForPeer = device.GetOutboundElementsContainer()
 				elemsByPeer[peer] = elemsForPeer
 			}
 			elemsForPeer.elems = append(elemsForPeer.elems, elem)
-			elems[i] = device.NewOutboundElement()
-			bufs[i] = elems[i].buffer[:]
+			elems[i] = device.GetOutboundElement()
 		}
 
 		for peer, elemsForPeer := range elemsByPeer {
@@ -398,7 +412,6 @@ func (peer *Peer) StagePackets(elems *QueueOutboundElementsContainer) {
 			select {
 			case tooOld := <-peer.queue.staged:
 				for _, elem := range tooOld.elems {
-					peer.device.PutMessageBuffer(elem.buffer)
 					peer.device.PutOutboundElement(elem)
 				}
 				peer.device.PutOutboundElementsContainer(tooOld)
@@ -407,7 +420,6 @@ func (peer *Peer) StagePackets(elems *QueueOutboundElementsContainer) {
 		}
 	}); !running {
 		for _, elem := range elems.elems {
-			peer.device.PutMessageBuffer(elem.buffer)
 			peer.device.PutOutboundElement(elem)
 		}
 		peer.device.PutOutboundElementsContainer(elems)
@@ -476,7 +488,6 @@ func (peer *Peer) FlushStagedPackets() {
 		select {
 		case elemsContainer := <-peer.queue.staged:
 			for _, elem := range elemsContainer.elems {
-				peer.device.PutMessageBuffer(elem.buffer)
 				peer.device.PutOutboundElement(elem)
 			}
 			peer.device.PutOutboundElementsContainer(elemsContainer)
@@ -516,7 +527,7 @@ func (device *Device) RoutineEncryption(id int) {
 	for elemsContainer := range device.queue.encryption.c {
 		for _, elem := range elemsContainer.elems {
 			// populate header fields
-			header := elem.buffer[MessageEncapsulatingTransportSize : MessageEncapsulatingTransportSize+MessageTransportHeaderSize]
+			header := elem.buffer.slab[elem.plaintextOffset-MessageTransportHeaderSize : elem.plaintextOffset]
 
 			fieldType := header[0:4]
 			fieldReceiver := header[4:8]
@@ -528,6 +539,7 @@ func (device *Device) RoutineEncryption(id int) {
 
 			// pad content to multiple of 16
 			paddingSize := calculatePaddingSize(len(elem.packet), int(device.tun.mtu.Load()))
+
 			elem.packet = append(elem.packet, paddingZeros[:paddingSize]...)
 
 			// encrypt content and release to consumer
@@ -541,7 +553,9 @@ func (device *Device) RoutineEncryption(id int) {
 			)
 
 			// re-slice packet to include encapsulating transport space
-			elem.packet = elem.buffer[:MessageEncapsulatingTransportSize+len(elem.packet)]
+			start := elem.plaintextOffset - MessageTransportHeaderSize - MessageEncapsulatingTransportSize
+			end := elem.plaintextOffset - MessageTransportHeaderSize + len(elem.packet)
+			elem.packet = elem.buffer.slab[start:end]
 		}
 		elemsContainer.filling.Done()
 	}
@@ -595,7 +609,6 @@ func (peer *Peer) processOutboundContainer(elemsContainer *QueueOutboundElements
 		// TODO: rework peer shutdown order to ensure
 		// that we never accidentally keep timers alive longer than necessary.
 		for _, elem := range elemsContainer.elems {
-			device.PutMessageBuffer(elem.buffer)
 			device.PutOutboundElement(elem)
 		}
 		return
@@ -617,7 +630,6 @@ func (peer *Peer) processOutboundContainer(elemsContainer *QueueOutboundElements
 		peer.timersDataSent()
 	}
 	for _, elem := range elemsContainer.elems {
-		device.PutMessageBuffer(elem.buffer)
 		device.PutOutboundElement(elem)
 	}
 	if err != nil {

--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -107,33 +107,34 @@ func CreateNetTUN(localAddresses, dnsServers []netip.Addr, mtu int) (tun.Device,
 	return dev, (*Net)(dev), nil
 }
 
-func (tun *netTun) Name() (string, error) {
+func (t *netTun) Name() (string, error) {
 	return "go", nil
 }
 
-func (tun *netTun) File() *os.File {
+func (t *netTun) File() *os.File {
 	return nil
 }
 
-func (tun *netTun) Events() <-chan tun.Event {
-	return tun.events
+func (t *netTun) Events() <-chan tun.Event {
+	return t.events
 }
 
-func (tun *netTun) Read(buf [][]byte, sizes []int, offset int) (int, error) {
-	view, ok := <-tun.incomingPacket
+func (t *netTun) Read(slab []byte, packets []tun.ReadPacket) (int, error) {
+	view, ok := <-t.incomingPacket
 	if !ok {
 		return 0, os.ErrClosed
 	}
 
-	n, err := view.Read(buf[0][offset:])
+	n, err := view.Read(slab[tun.ReadPacketSpacing : len(slab)-tun.ReadPacketSpacing])
 	if err != nil {
 		return 0, err
 	}
-	sizes[0] = n
+	packets[0].Size = n
+	packets[0].Offset = tun.ReadPacketSpacing
 	return 1, nil
 }
 
-func (tun *netTun) Write(buf [][]byte, offset int) (int, error) {
+func (t *netTun) Write(buf [][]byte, offset int) (int, error) {
 	for _, buf := range buf {
 		packet := buf[offset:]
 		if len(packet) == 0 {
@@ -143,9 +144,9 @@ func (tun *netTun) Write(buf [][]byte, offset int) (int, error) {
 		pkb := stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buffer.MakeWithData(packet)})
 		switch packet[0] >> 4 {
 		case 4:
-			tun.ep.InjectInbound(header.IPv4ProtocolNumber, pkb)
+			t.ep.InjectInbound(header.IPv4ProtocolNumber, pkb)
 		case 6:
-			tun.ep.InjectInbound(header.IPv6ProtocolNumber, pkb)
+			t.ep.InjectInbound(header.IPv6ProtocolNumber, pkb)
 		default:
 			return 0, syscall.EAFNOSUPPORT
 		}
@@ -153,8 +154,8 @@ func (tun *netTun) Write(buf [][]byte, offset int) (int, error) {
 	return len(buf), nil
 }
 
-func (tun *netTun) WriteNotify() {
-	pkt := tun.ep.Read()
+func (t *netTun) WriteNotify() {
+	pkt := t.ep.Read()
 	if pkt.IsNil() {
 		return
 	}
@@ -162,30 +163,30 @@ func (tun *netTun) WriteNotify() {
 	view := pkt.ToView()
 	pkt.DecRef()
 
-	tun.incomingPacket <- view
+	t.incomingPacket <- view
 }
 
-func (tun *netTun) Close() error {
-	tun.stack.RemoveNIC(1)
+func (t *netTun) Close() error {
+	t.stack.RemoveNIC(1)
 
-	if tun.events != nil {
-		close(tun.events)
+	if t.events != nil {
+		close(t.events)
 	}
 
-	tun.ep.Close()
+	t.ep.Close()
 
-	if tun.incomingPacket != nil {
-		close(tun.incomingPacket)
+	if t.incomingPacket != nil {
+		close(t.incomingPacket)
 	}
 
 	return nil
 }
 
-func (tun *netTun) MTU() (int, error) {
-	return tun.mtu, nil
+func (t *netTun) MTU() (int, error) {
+	return t.mtu, nil
 }
 
-func (tun *netTun) BatchSize() int {
+func (t *netTun) BatchSize() int {
 	return 1
 }
 

--- a/tun/offload.go
+++ b/tun/offload.go
@@ -2,6 +2,7 @@ package tun
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 )
 
@@ -73,15 +74,34 @@ const (
 	ipProtoUDP = 17
 )
 
-// GSOSplit splits packets from 'in' into outBufs[<index>][outOffset:], writing
-// the size of each element into sizes. It returns the number of buffers
-// populated, and/or an error. Callers may pass an 'in' slice that overlaps with
-// the first element of outBuffers, i.e. &in[0] may be equal to
-// &outBufs[0][outOffset]. GSONone is a valid options.GSOType regardless of the
-// value of options.NeedsCsum. Length of each outBufs element must be greater
-// than or equal to the length of 'in', otherwise output may be silently
-// truncated.
-func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outOffset int) (int, error) {
+// GSOSplit splits 'in' according to options and writes the resulting segments
+// into slab. It populates packets with each packet's offset and size and returns
+// the number of populated entries.
+//
+// spacing bytes are reserved before the first packet, between adjacent packets,
+// and after the final packet.
+//
+// 'in' may overlap slab only when in begins at slab[spacing]. Overlapping input
+// is modified and must not be used after this call.
+//
+// If packets or slab cannot accommodate every segment, GSOSplit returns the
+// number successfully written together with [ErrTooManySegments]. packets[:n]
+// remains valid.
+func GSOSplit(in []byte, options GSOOptions, slab []byte, packets []ReadPacket, spacing int) (int, error) {
+	if spacing < 0 {
+		return 0, errors.New("spacing must be nonnegative")
+	}
+
+	// return early if instructed to split with no split size
+	if options.GSOType != GSONone && options.GSOSize == 0 {
+		return 0, fmt.Errorf("invalid GSOType (%v) with zero GSOSize", options.GSOType)
+	}
+
+	// return early if we can't fill a single packet
+	if len(packets) == 0 || spacing > len(slab)/2 {
+		return 0, ErrTooManySegments
+	}
+
 	cSumAt := int(options.CsumStart) + int(options.CsumOffset)
 	if cSumAt+1 >= len(in) {
 		return 0, fmt.Errorf("end of checksum offset (%d) exceeds packet length (%d)", cSumAt+1, len(in))
@@ -91,20 +111,34 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 		return 0, fmt.Errorf("length of packet (%d) < GSO HdrLen (%d)", len(in), options.HdrLen)
 	}
 
-	// Handle the conditions where we are copying a single element to outBuffs.
+	// Handle the conditions where we are copying a single element to slab.
 	payloadLen := len(in) - int(options.HdrLen)
 	if options.GSOType == GSONone || payloadLen < int(options.GSOSize) {
-		if len(in) > len(outBufs[0][outOffset:]) {
-			return 0, fmt.Errorf("length of packet (%d) exceeds output element length (%d)", len(in), len(outBufs[0][outOffset:]))
+		// trim spacing on both ends
+		output := slab[spacing : len(slab)-spacing]
+
+		if len(in) > len(output) {
+			return 0, ErrTooManySegments
 		}
+
+		// slice to packet size, so checksum computation below is correct
+		singleOut := output[:len(in)]
+
+		// Copy before checksum computation, so that we don't mutate 'in' if
+		// 'in' and 'slab' happen to be disjoint.
+		copy(singleOut, in)
+		packets[0] = ReadPacket{
+			Offset: spacing,
+			Size:   len(singleOut),
+		}
+
 		if options.NeedsCsum {
 			// The initial value at the checksum offset should be summed with
 			// the checksum we compute. This is typically the pseudo-header sum.
-			initial := binary.BigEndian.Uint16(in[cSumAt:])
-			in[cSumAt], in[cSumAt+1] = 0, 0
-			binary.BigEndian.PutUint16(in[cSumAt:], ^Checksum(in[options.CsumStart:], initial))
+			initial := binary.BigEndian.Uint16(singleOut[cSumAt:])
+			singleOut[cSumAt], singleOut[cSumAt+1] = 0, 0
+			binary.BigEndian.PutUint16(singleOut[cSumAt:], ^Checksum(singleOut[options.CsumStart:], initial))
 		}
-		sizes[0] = copy(outBufs[0][outOffset:], in)
 		return 1, nil
 	}
 
@@ -132,6 +166,62 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 		return 0, fmt.Errorf("invalid ip header version: %d", ipVersion)
 	}
 
+	// Calculate how many segments fit in slab. I found it helpful to mentally
+	// model the slab as:
+	//
+	//	[leading spacing][packet][spacing][packet]...[spacing]
+	//
+	// If every packet were full-sized, after removing the leading spacing each
+	// packet consumes fullPacketSize+spacing bytes.
+	hdrLen := int(options.HdrLen)
+	gsoSize := int(options.GSOSize)
+	// equivalent to ceil(payloadLen / gsoSize), but overflow safe if payloadLen
+	// is close to bounds
+	totalOutSegments := payloadLen / gsoSize
+	if payloadLen%gsoSize != 0 {
+		totalOutSegments++
+	}
+	// how many full gso-sized segments would fit in slab
+	fullPacketSize := hdrLen + gsoSize
+	fullFit := (len(slab) - spacing) / (fullPacketSize + spacing)
+	// this min does not yet account for a smaller tail
+	n := min(totalOutSegments, len(packets), fullFit)
+
+	// Account for the potentially shorter final segment. The exact layout needs
+	// one header per segment, the original payload bytes, and N+1 spacing
+	// regions.
+	requiredBytesLen :=
+		totalOutSegments*hdrLen +
+			payloadLen +
+			(totalOutSegments+1)*spacing
+	if len(packets) >= totalOutSegments && requiredBytesLen <= len(slab) {
+		// n was previously calculated assuming totalOutSegments were all of
+		// gsoSize, but the tail segment may be smaller than gsoSize. If a
+		// smaller than gsoSize tail fits, we can bump n back to totalOutSegments,
+		// assuming packets is long enough.
+		n = totalOutSegments
+	}
+
+	// n is the number of leading segments that fit.
+	//
+	// Since input and output may overlap, split back-to-front. Splitting
+	// front-to-back could overwrite input before it is copied.
+	//
+	// H is the header; A, B, and C are payload segments.
+	//
+	//	Input:
+	//	[ H | A | B | C ]
+	//
+	//	Desired output:
+	//	[ H | A | gap | H | B | gap | H | C ]
+	//
+	//	Front-to-back could overwrite unread B/C:
+	//	[ H | A | gap | H ... ]
+	//	          └── overwrites remaining input ──┘
+	//
+	// For the same reason, copy each segment's payload before its headers.
+
+	// Identify IP addr offsets and length, transport protocol, and transport offsets.
 	iphLen := int(options.CsumStart)
 	srcAddrOffset := ipv6SrcAddrOffset
 	addrLen := 16
@@ -152,22 +242,61 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 	} else {
 		protocol = ipProtoUDP
 	}
-	nextSegmentDataAt := int(options.HdrLen)
-	i := 0
-	for ; nextSegmentDataAt < len(in); i++ {
-		if i == len(outBufs) {
-			return i - 1, ErrTooManySegments
-		}
-		nextSegmentEnd := nextSegmentDataAt + int(options.GSOSize)
-		if nextSegmentEnd > len(in) {
-			nextSegmentEnd = len(in)
-		}
-		segmentDataLen := nextSegmentEnd - nextSegmentDataAt
-		totalLen := int(options.HdrLen) + segmentDataLen
-		sizes[i] = totalLen
-		out := outBufs[i][outOffset:]
 
-		copy(out, in[:iphLen])
+	// The segment-writing loop indexes these fixed IP and transport header
+	// fields within out[:hdrLen]. Validate that each field fits before
+	// modifying slab.
+	csumStart := int(options.CsumStart)
+	csumAt := csumStart + int(options.CsumOffset)
+	if ipVersion == 4 {
+		if hdrLen < 20 {
+			return 0, fmt.Errorf("IPv4 header exceeds GSO header length %d", hdrLen)
+		}
+	} else {
+		if hdrLen < 40 {
+			return 0, fmt.Errorf("IPv6 header exceeds GSO header length %d", hdrLen)
+		}
+	}
+	if protocol == ipProtoTCP {
+		if hdrLen < csumStart+20 {
+			return 0, fmt.Errorf(
+				"TCP header at offset %d exceeds GSO header length %d",
+				csumStart, hdrLen,
+			)
+		}
+	} else {
+		if hdrLen < csumStart+8 {
+			return 0, fmt.Errorf(
+				"UDP header at offset %d exceeds GSO header length %d",
+				csumStart, hdrLen,
+			)
+		}
+	}
+	if hdrLen < csumAt+2 {
+		return 0, fmt.Errorf(
+			"checksum field at offset %d exceeds GSO header length %d",
+			csumAt, hdrLen,
+		)
+	}
+
+	// Split back-to-front
+	for i := n - 1; i >= 0; i-- {
+		// identify input and output offsets
+		payloadStart := hdrLen + (i * gsoSize)
+		payloadEnd := min(payloadStart+gsoSize, len(in))
+		payloadSize := payloadEnd - payloadStart
+		packetSize := hdrLen + payloadSize
+		outOffset := spacing + i*(fullPacketSize+spacing)
+		out := slab[outOffset : outOffset+packetSize]
+		packets[i] = ReadPacket{
+			Offset: outOffset,
+			Size:   packetSize,
+		}
+
+		// Copy payload first because in and out may overlap.
+		copy(out[hdrLen:], in[payloadStart:payloadEnd])
+		copy(out[:hdrLen], in[:hdrLen])
+
 		if ipVersion == 4 {
 			// For IPv4 we are responsible for incrementing the ID field,
 			// updating the total len field, and recalculating the header
@@ -177,44 +306,57 @@ func GSOSplit(in []byte, options GSOOptions, outBufs [][]byte, sizes []int, outO
 				id += uint16(i)
 				binary.BigEndian.PutUint16(out[4:], id)
 			}
-			out[10], out[11] = 0, 0 // clear ipv4 header checksum
-			binary.BigEndian.PutUint16(out[2:], uint16(totalLen))
-			ipv4CSum := ^Checksum(out[:iphLen], 0)
-			binary.BigEndian.PutUint16(out[10:], ipv4CSum)
+			// clear ipv4 header checksum
+			out[10], out[11] = 0, 0
+			// update total len
+			binary.BigEndian.PutUint16(out[2:], uint16(packetSize))
+			// compute & set updated checksum
+			binary.BigEndian.PutUint16(out[10:], ^Checksum(out[:iphLen], 0))
 		} else {
 			// For IPv6 we are responsible for updating the payload length field.
-			binary.BigEndian.PutUint16(out[4:], uint16(totalLen-iphLen))
+			binary.BigEndian.PutUint16(out[4:], uint16(packetSize-iphLen))
 		}
-
-		// copy transport header
-		copy(out[options.CsumStart:options.HdrLen], in[options.CsumStart:options.HdrLen])
 
 		if protocol == ipProtoTCP {
 			// set TCP seq and adjust TCP flags
-			tcpSeq := firstTCPSeqNum + uint32(options.GSOSize*uint16(i))
-			binary.BigEndian.PutUint32(out[options.CsumStart+4:], tcpSeq)
-			if nextSegmentEnd != len(in) {
-				// FIN and PSH should only be set on last segment
+			seq := firstTCPSeqNum + uint32(i*gsoSize)
+			binary.BigEndian.PutUint32(out[options.CsumStart+4:], seq)
+
+			if payloadEnd != len(in) {
+				// FIN and PSH should only be set on last segment. Last
+				// specifically means last input segment, not last output, which
+				// could be last fitting, but not last input.
 				clearFlags := tcpFlagFIN | tcpFlagPSH
 				out[options.CsumStart+tcpFlagsOffset] &^= clearFlags
 			}
 		} else {
 			// set UDP header len
-			binary.BigEndian.PutUint16(out[options.CsumStart+4:], uint16(segmentDataLen)+(options.HdrLen-options.CsumStart))
+			udpLen := uint16(payloadSize) + options.HdrLen - options.CsumStart
+			binary.BigEndian.PutUint16(out[options.CsumStart+4:], udpLen)
 		}
-
-		// payload
-		copy(out[options.HdrLen:], in[nextSegmentDataAt:nextSegmentEnd])
 
 		// transport checksum
 		out[transportCsumAt], out[transportCsumAt+1] = 0, 0 // clear tcp/udp checksum
 		transportHeaderLen := int(options.HdrLen - options.CsumStart)
-		lenForPseudo := uint16(transportHeaderLen + segmentDataLen)
-		transportCSum := PseudoHeaderChecksum(protocol, in[srcAddrOffset:srcAddrOffset+addrLen], in[srcAddrOffset+addrLen:srcAddrOffset+addrLen*2], lenForPseudo)
-		transportCSum = ^Checksum(out[options.CsumStart:totalLen], transportCSum)
-		binary.BigEndian.PutUint16(out[options.CsumStart+options.CsumOffset:], transportCSum)
-
-		nextSegmentDataAt += int(options.GSOSize)
+		pseudoLen := uint16(transportHeaderLen + payloadSize)
+		transportCSum := PseudoHeaderChecksum(
+			protocol,
+			in[srcAddrOffset:srcAddrOffset+addrLen],
+			in[srcAddrOffset+addrLen:srcAddrOffset+2*addrLen],
+			pseudoLen,
+		)
+		transportCSum = ^Checksum(
+			out[options.CsumStart:packetSize],
+			transportCSum,
+		)
+		binary.BigEndian.PutUint16(
+			out[options.CsumStart+options.CsumOffset:],
+			transportCSum,
+		)
 	}
-	return i, nil
+
+	if n < totalOutSegments {
+		return n, ErrTooManySegments
+	}
+	return n, nil
 }

--- a/tun/offload_linux_test.go
+++ b/tun/offload_linux_test.go
@@ -235,13 +235,10 @@ func Test_handleVirtioRead(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := make([][]byte, conn.IdealBatchSize)
-			sizes := make([]int, conn.IdealBatchSize)
-			for i := range out {
-				out[i] = make([]byte, 65535)
-			}
+			out := make([]byte, 2*(1<<16-1))
+			packets := make([]ReadPacket, conn.IdealBatchSize)
 			tt.hdr.encode(tt.pktIn)
-			n, err := handleVirtioRead(tt.pktIn, out, sizes, offset)
+			n, err := handleVirtioRead(tt.pktIn, out, packets)
 			if err != nil {
 				if tt.wantErr {
 					return
@@ -251,9 +248,24 @@ func Test_handleVirtioRead(t *testing.T) {
 			if n != len(tt.wantLens) {
 				t.Fatalf("got %d packets, wanted %d", n, len(tt.wantLens))
 			}
-			for i := range tt.wantLens {
-				if tt.wantLens[i] != sizes[i] {
-					t.Fatalf("wantLens[%d]: %d != outSizes: %d", i, tt.wantLens[i], sizes[i])
+			for i, wantLen := range tt.wantLens {
+				if packets[i].Size != wantLen {
+					t.Fatalf(
+						"packet[%d] size: got %d, want %d",
+						i, packets[i].Size, wantLen,
+					)
+				}
+
+				wantOffset := ReadPacketSpacing
+				if i > 0 {
+					prev := packets[i-1]
+					wantOffset = prev.Offset + prev.Size + ReadPacketSpacing
+				}
+				if packets[i].Offset != wantOffset {
+					t.Fatalf(
+						"packet[%d] offset: got %d, want %d",
+						i, packets[i].Offset, wantOffset,
+					)
 				}
 			}
 		})

--- a/tun/offload_test.go
+++ b/tun/offload_test.go
@@ -1,13 +1,316 @@
 package tun
 
 import (
+	"errors"
+	"fmt"
 	"net/netip"
+	"slices"
 	"testing"
 
 	"github.com/tailscale/wireguard-go/conn"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 )
+
+// TestGSOSplitOverlappingInputs verifies that GSOSplit produces correct segments
+// when in overlaps slab, without overwriting unread input.
+func TestGSOSplitOverlappingInput(t *testing.T) {
+	const (
+		spacing    = ReadPacketSpacing
+		hdrLen     = 28 // 20-byte IPv4 header + 8-byte UDP header
+		payloadLen = 250
+		gsoSize    = 100
+		slabLen    = 1024
+	)
+
+	newInput := func() []byte {
+		in := make([]byte, hdrLen+payloadLen)
+		in[0] = 4 << 4 // IPv4
+		for i := range in[hdrLen:] {
+			in[hdrLen+i] = byte(i)
+		}
+		return in
+	}
+
+	options := GSOOptions{
+		GSOType:    GSOUDPL4,
+		HdrLen:     hdrLen,
+		CsumStart:  20,
+		CsumOffset: 6,
+		GSOSize:    gsoSize,
+	}
+
+	// Generate reference output using disjoint input and output.
+	wantSlab := make([]byte, slabLen)
+	wantPackets := make([]ReadPacket, 3)
+	wantN, err := GSOSplit(
+		newInput(),
+		options,
+		wantSlab,
+		wantPackets,
+		spacing,
+	)
+	if err != nil {
+		t.Fatalf("GSOSplit with disjoint input: %v", err)
+	}
+
+	// Place the input at the documented overlapping location.
+	gotSlab := make([]byte, slabLen)
+	in := newInput()
+	overlappingIn := gotSlab[spacing : spacing+len(in)]
+	copy(overlappingIn, in)
+
+	gotPackets := make([]ReadPacket, 3)
+	gotN, err := GSOSplit(
+		overlappingIn,
+		options,
+		gotSlab,
+		gotPackets,
+		spacing,
+	)
+	if err != nil {
+		t.Fatalf("GSOSplit with overlapping input: %v", err)
+	}
+
+	if gotN != wantN {
+		t.Fatalf("got %d packets, want %d", gotN, wantN)
+	}
+
+	for i := range gotN {
+		if gotPackets[i] != wantPackets[i] {
+			t.Errorf(
+				"packets[%d] = %+v, want %+v",
+				i,
+				gotPackets[i],
+				wantPackets[i],
+			)
+			continue
+		}
+
+		got := gotPackets[i]
+		want := wantPackets[i]
+
+		gotBytes := gotSlab[got.Offset : got.Offset+got.Size]
+		wantBytes := wantSlab[want.Offset : want.Offset+want.Size]
+		if !slices.Equal(gotBytes, wantBytes) {
+			t.Errorf("packet %d differs with overlapping input", i)
+		}
+	}
+}
+
+// TestGSOSplitPartialCapacity verifies that GSOSplit handles inputs that exceed
+// the capacity of the output slab, packet descriptors, or both.
+func TestGSOSplitPartialCapacity(t *testing.T) {
+	const (
+		spacing       = 10
+		hdrLen        = 28 // 20-byte IPv4 header + 8-byte UDP header
+		gsoSize       = 100
+		fullPacketLen = hdrLen + gsoSize
+
+		threeFullFit = 4*spacing + 3*fullPacketLen
+		shortTailFit = 4*spacing + 2*fullPacketLen + hdrLen + 50
+	)
+
+	tests := []struct {
+		name       string
+		payloadLen int
+		slabLen    int
+		packetCap  int
+		wantSizes  []int
+		wantErr    bool
+	}{
+		{
+			name:       "exact fit of full segments",
+			payloadLen: 300,
+			slabLen:    threeFullFit,
+			packetCap:  3,
+			wantSizes:  []int{128, 128, 128},
+		},
+		{
+			name:       "exact fit with short tail",
+			payloadLen: 250,
+			slabLen:    shortTailFit,
+			packetCap:  3,
+			wantSizes:  []int{128, 128, 78},
+		},
+		{
+			name:       "one byte short of short tail",
+			payloadLen: 250,
+			slabLen:    shortTailFit - 1,
+			packetCap:  3,
+			wantSizes:  []int{128, 128},
+			wantErr:    true,
+		},
+		{
+			name:       "packet descriptor exhaustion",
+			payloadLen: 250,
+			slabLen:    shortTailFit,
+			packetCap:  2,
+			wantSizes:  []int{128, 128},
+			wantErr:    true,
+		},
+		{
+			name:       "no segment fits",
+			payloadLen: 250,
+			slabLen:    2*spacing + fullPacketLen - 1,
+			packetCap:  3,
+			wantErr:    true,
+		},
+	}
+
+	options := GSOOptions{
+		GSOType:    GSOUDPL4,
+		HdrLen:     hdrLen,
+		CsumStart:  20,
+		CsumOffset: 6,
+		GSOSize:    gsoSize,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := make([]byte, hdrLen+tt.payloadLen)
+			in[0] = 4 << 4 // IPv4
+
+			for i := range in[hdrLen:] {
+				in[hdrLen+i] = byte(i)
+			}
+
+			slab := make([]byte, tt.slabLen)
+			packets := make([]ReadPacket, tt.packetCap)
+
+			n, err := GSOSplit(in, options, slab, packets, spacing)
+			if n != len(tt.wantSizes) {
+				t.Fatalf("n = %d, want %d", n, len(tt.wantSizes))
+			}
+			if tt.wantErr {
+				if !errors.Is(err, ErrTooManySegments) {
+					t.Fatalf("error = %v, want ErrTooManySegments", err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for i, wantSize := range tt.wantSizes {
+				got := packets[i]
+
+				if got.Size != wantSize {
+					t.Errorf(
+						"packets[%d].Size = %d, want %d",
+						i,
+						got.Size,
+						wantSize,
+					)
+				}
+
+				wantOffset := spacing + i*(fullPacketLen+spacing)
+				if got.Offset != wantOffset {
+					t.Errorf(
+						"packets[%d].Offset = %d, want %d",
+						i,
+						got.Offset,
+						wantOffset,
+					)
+				}
+
+				payloadStart := i * gsoSize
+				payloadEnd := min(payloadStart+gsoSize, tt.payloadLen)
+
+				gotPayload := slab[got.Offset+hdrLen : got.Offset+got.Size]
+				wantPayload := in[hdrLen+payloadStart : hdrLen+payloadEnd]
+				if !slices.Equal(gotPayload, wantPayload) {
+					t.Errorf("packets[%d] has incorrect payload", i)
+				}
+			}
+		})
+	}
+}
+
+// TestGSOSplitMinimumGSOSize documents the minimum GSO size at which a
+// maximum-sized IPv4 packet can be completely split into [conn.IdealBatchSize]
+// packet descriptors. GSO size 512 produces 128 segments; 511 produces 129.
+func TestGSOSplitMinimumGSOSize(t *testing.T) {
+	// Any changes to [conn.IdealBatchSize] should consider impacts on
+	// segmentation splitting limits.
+	if conn.IdealBatchSize != 128 {
+		t.Fatalf("conn.IdealBatchSize = %d, want 128", conn.IdealBatchSize)
+	}
+
+	const (
+		maxPacketSize = 1<<16 - 1
+		slabSize      = 2 * (1<<16 - 1)
+		minGSOSize    = 512
+	)
+
+	tests := []struct {
+		name       string
+		gsoType    GSOType
+		hdrLen     uint16
+		csumOffset uint16
+	}{
+		{
+			name:       "UDP",
+			gsoType:    GSOUDPL4,
+			hdrLen:     28,
+			csumOffset: 6,
+		},
+		{
+			name:       "TCP",
+			gsoType:    GSOTCPv4,
+			hdrLen:     40,
+			csumOffset: 16,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := make([]byte, maxPacketSize)
+			in[0] = 4 << 4 // IPv4
+
+			for _, gsoSize := range []int{minGSOSize, minGSOSize - 1} {
+				t.Run(fmt.Sprint(gsoSize), func(t *testing.T) {
+					payloadLen := len(in) - int(tt.hdrLen)
+					wantSegments :=
+						(payloadLen + gsoSize - 1) / gsoSize
+
+					slab := make([]byte, slabSize)
+					packets := make([]ReadPacket, conn.IdealBatchSize)
+
+					n, err := GSOSplit(
+						in,
+						GSOOptions{
+							GSOType:    tt.gsoType,
+							HdrLen:     tt.hdrLen,
+							CsumStart:  20,
+							CsumOffset: tt.csumOffset,
+							GSOSize:    uint16(gsoSize),
+						},
+						slab,
+						packets,
+						ReadPacketSpacing,
+					)
+
+					wantN := min(
+						wantSegments,
+						conn.IdealBatchSize,
+					)
+					if n != wantN {
+						t.Fatalf("n = %d, want %d", n, wantN)
+					}
+
+					wantErr := wantSegments > conn.IdealBatchSize
+					if got := errors.Is(err, ErrTooManySegments); got != wantErr {
+						t.Fatalf(
+							"ErrTooManySegments = %v, want %v; err = %v",
+							got,
+							wantErr,
+							err,
+						)
+					}
+				})
+			}
+		})
+	}
+}
 
 func Fuzz_GSOSplit(f *testing.F) {
 	const segmentSize = 100
@@ -45,7 +348,7 @@ func Fuzz_GSOSplit(f *testing.F) {
 		TTL:         64,
 		TotalLength: uint16(len(gsoUDPv4)),
 	})
-	header.UDP(gsoTCPv4[20:]).Encode(udpFields)
+	header.UDP(gsoUDPv4[20:]).Encode(udpFields)
 
 	gsoTCPv6 := make([]byte, 40+20+segmentSize)
 	header.IPv6(gsoTCPv6).Encode(&header.IPv6Fields{
@@ -65,13 +368,10 @@ func Fuzz_GSOSplit(f *testing.F) {
 		HopLimit:          64,
 		PayloadLength:     uint16(8 + segmentSize),
 	})
-	header.UDP(gsoUDPv6[20:]).Encode(udpFields)
+	header.UDP(gsoUDPv6[40:]).Encode(udpFields)
 
-	out := make([][]byte, conn.IdealBatchSize)
-	for i := range out {
-		out[i] = make([]byte, 65535)
-	}
-	sizes := make([]int, conn.IdealBatchSize)
+	out := make([]byte, 2*(1<<16-1))
+	packets := make([]ReadPacket, conn.IdealBatchSize)
 
 	f.Add(gsoTCPv4, int(GSOTCPv4), uint16(40), uint16(20), uint16(16), uint16(100), false)
 	f.Add(gsoUDPv4, int(GSOUDPL4), uint16(28), uint16(20), uint16(6), uint16(100), false)
@@ -87,9 +387,9 @@ func Fuzz_GSOSplit(f *testing.F) {
 			GSOSize:    gsoSize,
 			NeedsCsum:  needsCsum,
 		}
-		n, _ := GSOSplit(pkt, options, out, sizes, 0)
-		if n > len(sizes) {
-			t.Errorf("n (%d) > len(sizes): %d", n, len(sizes))
+		n, _ := GSOSplit(pkt, options, out, packets, ReadPacketSpacing)
+		if n > len(packets) {
+			t.Errorf("n (%d) > len(packets): %d", n, len(packets))
 		}
 	})
 }

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -17,16 +17,35 @@ const (
 	EventMTUUpdate
 )
 
+// ReadPacket describes a packet read by [tun.Device.Read].
+type ReadPacket struct {
+	// Offset is the starting byte offset.
+	Offset int
+	// Size is the size of the packet.
+	Size int
+}
+
+// ReadPacketSpacing is the number of bytes reserved before the first packet,
+// between adjacent packets, and after the final packet filled by [Device.Read].
+const ReadPacketSpacing = 64
+
 type Device interface {
 	// File returns the file descriptor of the device.
 	File() *os.File
 
-	// Read one or more packets from the Device (without any additional headers).
-	// On a successful read it returns the number of packets read, and sets
-	// packet lengths within the sizes slice. len(sizes) must be >= len(bufs).
-	// A nonzero offset can be used to instruct the Device on where to begin
-	// reading into each element of the bufs slice.
-	Read(bufs [][]byte, sizes []int, offset int) (n int, err error)
+	// Read reads one or more packets from the [Device] into slab. On return, it
+	// populates packets and returns the number of entries to evaluate. Those
+	// entries are valid even when err is non-nil. Callers must provide at least
+	// [Device.BatchSize] entries.
+	//
+	// Read reserves [ReadPacketSpacing] bytes before the first packet, between
+	// adjacent packets, and after the final packet. The contents of the reserved
+	// space are unspecified; the [Device] may use them while Read is executing.
+	// Callers must provide a slab of at least 2*[ReadPacketSpacing] bytes.
+	//
+	// Read returns [ErrTooManySegments] if packets or slab cannot accommodate
+	// all packets produced by the read.
+	Read(slab []byte, packets []ReadPacket) (n int, err error)
 
 	// Write one or more packets to the device (without any additional headers).
 	// On a successful write it returns the number of packets written. A nonzero

--- a/tun/tun_darwin.go
+++ b/tun/tun_darwin.go
@@ -217,7 +217,7 @@ func (tun *NativeTun) Events() <-chan Event {
 	return tun.events
 }
 
-func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+func (tun *NativeTun) Read(slab []byte, packets []ReadPacket) (int, error) {
 	// TODO: the BSDs look very similar in Read() and Write(). They should be
 	// collapsed, with platform-specific files containing the varying parts of
 	// their implementations.
@@ -225,12 +225,13 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		buf := bufs[0][offset-4:]
+		buf := slab[ReadPacketSpacing-4 : len(slab)-ReadPacketSpacing]
 		n, err := tun.tunFile.Read(buf[:])
 		if n < 4 {
 			return 0, err
 		}
-		sizes[0] = n - 4
+		packets[0].Offset = ReadPacketSpacing
+		packets[0].Size = n - 4
 		return 1, err
 	}
 }

--- a/tun/tun_freebsd.go
+++ b/tun/tun_freebsd.go
@@ -333,17 +333,18 @@ func (tun *NativeTun) Events() <-chan Event {
 	return tun.events
 }
 
-func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+func (tun *NativeTun) Read(slab []byte, packets []ReadPacket) (int, error) {
 	select {
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		buf := bufs[0][offset-4:]
+		buf := slab[ReadPacketSpacing-4 : len(slab)-ReadPacketSpacing]
 		n, err := tun.tunFile.Read(buf[:])
 		if n < 4 {
 			return 0, err
 		}
-		sizes[0] = n - 4
+		packets[0].Offset = ReadPacketSpacing
+		packets[0].Size = n - 4
 		return 1, err
 	}
 }

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -409,10 +409,11 @@ func (tun *NativeTun) Write(bufs [][]byte, offset int) (int, error) {
 	return total, errs
 }
 
-// handleVirtioRead splits in into bufs, leaving offset bytes at the front of
-// each buffer. It mutates sizes to reflect the size of each element of bufs,
-// and returns the number of packets read.
-func handleVirtioRead(in []byte, bufs [][]byte, sizes []int, offset int) (int, error) {
+// handleVirtioRead splits in into slab, leaving [ReadPacketSpacing] bytes at
+// the front of the first packet, between every adjacent packet, and at the end
+// of the last packet. It mutates packets to reflect the size and offset of each
+// packet in slab, and returns the number of packets read.
+func handleVirtioRead(in []byte, slab []byte, packets []ReadPacket) (int, error) {
 	var hdr virtioNetHdr
 	err := hdr.decode(in)
 	if err != nil {
@@ -444,17 +445,17 @@ func handleVirtioRead(in []byte, bufs [][]byte, sizes []int, offset int) (int, e
 		options.HdrLen = options.CsumStart + tcpHLen
 	}
 
-	return GSOSplit(in, options, bufs, sizes, offset)
+	return GSOSplit(in, options, slab, packets, ReadPacketSpacing)
 }
 
-func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+func (tun *NativeTun) Read(slab []byte, packets []ReadPacket) (int, error) {
 	tun.readOpMu.Lock()
 	defer tun.readOpMu.Unlock()
 	select {
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		readInto := bufs[0][offset:]
+		readInto := slab[ReadPacketSpacing : len(slab)-ReadPacketSpacing]
 		if tun.vnetHdr {
 			readInto = tun.readBuff[:]
 		}
@@ -466,9 +467,10 @@ func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) 
 			return 0, err
 		}
 		if tun.vnetHdr {
-			return handleVirtioRead(readInto[:n], bufs, sizes, offset)
+			return handleVirtioRead(readInto[:n], slab, packets)
 		} else {
-			sizes[0] = n
+			packets[0].Size = n
+			packets[0].Offset = ReadPacketSpacing
 			return 1, nil
 		}
 	}

--- a/tun/tun_openbsd.go
+++ b/tun/tun_openbsd.go
@@ -204,17 +204,18 @@ func (tun *NativeTun) Events() <-chan Event {
 	return tun.events
 }
 
-func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+func (tun *NativeTun) Read(slab []byte, packets []ReadPacket) (int, error) {
 	select {
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		buf := bufs[0][offset-4:]
+		buf := slab[ReadPacketSpacing-4 : len(slab)-ReadPacketSpacing]
 		n, err := tun.tunFile.Read(buf[:])
 		if n < 4 {
 			return 0, err
 		}
-		sizes[0] = n - 4
+		packets[0].Offset = ReadPacketSpacing
+		packets[0].Size = n - 4
 		return 1, err
 	}
 }

--- a/tun/tun_plan9.go
+++ b/tun/tun_plan9.go
@@ -81,18 +81,18 @@ func (tun *NativeTun) Events() <-chan Event {
 	return tun.events
 }
 
-func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+func (tun *NativeTun) Read(slab []byte, packets []ReadPacket) (int, error) {
 	select {
 	case err := <-tun.errors:
 		return 0, err
 	default:
-		n, err := tun.dataFile.Read(bufs[0][offset:])
-		if n == 1 && bufs[0][offset] == 0 {
+		n, err := tun.dataFile.Read(slab[ReadPacketSpacing : len(slab)-ReadPacketSpacing])
+		if n == 1 && slab[ReadPacketSpacing] == 0 {
 			// EOF
-			err = io.EOF
-			n = 0
+			return 0, io.EOF
 		}
-		sizes[0] = n
+		packets[0].Offset = ReadPacketSpacing
+		packets[0].Size = n
 		return 1, err
 	}
 }

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -144,7 +144,7 @@ func (tun *NativeTun) BatchSize() int {
 
 // Note: Read() and Write() assume the caller comes only from a single thread; there's no locking.
 
-func (tun *NativeTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+func (tun *NativeTun) Read(slab []byte, packets []ReadPacket) (int, error) {
 	tun.running.Add(1)
 	defer tun.running.Done()
 retry:
@@ -160,11 +160,16 @@ retry:
 		packet, err := tun.session.ReceivePacket()
 		switch err {
 		case nil:
-			packetSize := len(packet)
-			copy(bufs[0][offset:], packet)
-			sizes[0] = packetSize
+			dst := slab[ReadPacketSpacing : len(slab)-ReadPacketSpacing]
+			if len(packet) > len(dst) {
+				tun.session.ReleaseReceivePacket(packet)
+				return 0, ErrTooManySegments
+			}
+			n := copy(dst, packet)
+			packets[0].Offset = ReadPacketSpacing
+			packets[0].Size = n
 			tun.session.ReleaseReceivePacket(packet)
-			tun.rate.update(uint64(packetSize))
+			tun.rate.update(uint64(n))
 			return 1, nil
 		case windows.ERROR_NO_MORE_ITEMS:
 			if !shouldSpin || uint64(nanotime()-start) >= spinloopDuration {

--- a/tun/tuntest/tuntest.go
+++ b/tun/tuntest/tuntest.go
@@ -110,13 +110,14 @@ type chTun struct {
 
 func (t *chTun) File() *os.File { return nil }
 
-func (t *chTun) Read(packets [][]byte, sizes []int, offset int) (int, error) {
+func (t *chTun) Read(slab []byte, packets []tun.ReadPacket) (int, error) {
 	select {
 	case <-t.c.closed:
 		return 0, os.ErrClosed
 	case msg := <-t.c.Outbound:
-		n := copy(packets[0][offset:], msg)
-		sizes[0] = n
+		n := copy(slab[tun.ReadPacketSpacing:len(slab)-tun.ReadPacketSpacing], msg)
+		packets[0].Offset = tun.ReadPacketSpacing
+		packets[0].Size = n
 		return 1, nil
 	}
 }


### PR DESCRIPTION
Use a single backing array instead of independent backing arrays. This greatly reduces peak RSS under load, and throughput improves in all cases.

The following throughput and peak RSS benchmarks were performed with iperf3 between two Intel i5-12400 nodes running Ubuntu 24.04 (Linux 6.8).

UDP benchmarks did not use UDP GSO on sender, so they were roughly equivalent to single packet ops through wireguard-go.

TCP/1 signifies 1 TCP stream; TCP/128 signifies 128 parallel TCP streams.

```csv
Throughput (Mb/s)
  Test     Before  After  Change
  TCP/1    13,587  15,682  +15.42%
  TCP/128  11,198  14,241  +27.18%
  UDP/1     2,624   3,535  +34.74%
  UDP/128   2,217   2,853  +28.68%

Peak memory (VmHWM, kB)
  Test     Side  Before    After   Change
  TCP/1    TX     186,468   33,248  -82.17%
           RX     255,392   38,840  -84.79%
  TCP/128  TX     362,908  226,840  -37.49%
           RX   1,721,532  295,236  -82.85%
  UDP/1    TX      17,980   16,720   -7.01%
           RX      69,260   13,380  -80.68%
  UDP/128  TX      16,708   16,488   -1.32%
           RX      65,536   20,856  -68.18%
```

Updates tailscale/corp#46716
Updates tailscale/corp#22467
Updates tailscale/corp#36989
Updates tailscale/corp#37878
