### PR TITLE
device: support PSKs in lazy peer config

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -466,6 +466,7 @@ func (device *Device) LookupPeer(pk NoisePublicKey) *Peer {
 		device.log.Errorf("Failed to create peer: %v", err)
 		return nil
 	}
+	p.SetPresharedKey(conf.PresharedKey)
 	p.SetAllowedIPs(conf.AllowedIPs)
 	p.deleteOnIdle = true
 	if conf.Endpoint != nil {
@@ -536,6 +537,10 @@ func (device *Device) RemoveMatchingPeers(shouldRemove func(NoisePublicKey) bool
 type NewPeerConfig struct {
 	// AllowedIPs is the initial set of allowed IPs for the new peer.
 	AllowedIPs []netip.Prefix
+
+	// PresharedKey is the initial pre-shared key for the new peer. The zero
+	// value disables the optional WireGuard pre-shared-key layer.
+	PresharedKey NoisePresharedKey
 
 	// Endpoint, if non-nil, sets the endpoint for newly created peers.
 	// The endpoint is pinned for the lifetime of the peer.

--- a/device/lookup_peer_test.go
+++ b/device/lookup_peer_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/tailscale/wireguard-go/conn"
 )
 
-func TestLookupPeerPinsEndpoint(t *testing.T) {
+func TestLookupPeerConfig(t *testing.T) {
 	dev := newTestDevice(t)
 	peerKey := NoisePublicKey{1}
+	psk := NoisePresharedKey{2}
 	initial, err := CreateDummyEndpoint()
 	if err != nil {
 		t.Fatalf("CreateDummyEndpoint: %v", err)
@@ -22,7 +23,7 @@ func TestLookupPeerPinsEndpoint(t *testing.T) {
 		if pk != peerKey {
 			return nil, false
 		}
-		return &NewPeerConfig{Endpoint: initial}, true
+		return &NewPeerConfig{Endpoint: initial, PresharedKey: psk}, true
 	})
 
 	peer := dev.LookupPeer(peerKey)
@@ -33,5 +34,20 @@ func TestLookupPeerPinsEndpoint(t *testing.T) {
 
 	if peer.endpoint.val != conn.Endpoint(initial) {
 		t.Fatalf("initial endpoint = %v, want %v", peer.endpoint.val, initial)
+	}
+	peer.handshake.mutex.RLock()
+	gotPSK := peer.handshake.presharedKey
+	peer.handshake.mutex.RUnlock()
+	if gotPSK != psk {
+		t.Fatalf("initial preshared key = %x, want %x", gotPSK, psk)
+	}
+
+	newPSK := NoisePresharedKey{3}
+	peer.SetPresharedKey(newPSK)
+	peer.handshake.mutex.RLock()
+	gotPSK = peer.handshake.presharedKey
+	peer.handshake.mutex.RUnlock()
+	if gotPSK != newPSK {
+		t.Fatalf("updated preshared key = %x, want %x", gotPSK, newPSK)
 	}
 }

--- a/device/peer.go
+++ b/device/peer.go
@@ -172,6 +172,14 @@ func (p *Peer) SetAllowedIPs(allowedIPs []netip.Prefix) {
 	p.state.testAllowedIP.Store(&f)
 }
 
+// SetPresharedKey sets the optional WireGuard pre-shared key for this peer.
+// The zero value disables the pre-shared-key layer.
+func (p *Peer) SetPresharedKey(psk NoisePresharedKey) {
+	p.handshake.mutex.Lock()
+	defer p.handshake.mutex.Unlock()
+	p.handshake.presharedKey = psk
+}
+
 // SendBuffers sends buffers to peer. WireGuard packet data in each element of
 // buffers must be preceded by MessageEncapsulatingTransportSize number of
 // bytes.


### PR DESCRIPTION
Add PresharedKey to NewPeerConfig and an exported setter so callers
can configure both newly-created and active peers.

Updates tailscale/tailcat#84
